### PR TITLE
Format whitespace around parentheses consistently

### DIFF
--- a/examples/astat.py
+++ b/examples/astat.py
@@ -100,4 +100,3 @@ if __name__ == "__main__":
         print(str(e))
         traceback.print_exc()
         os._exit(1)
-

--- a/examples/bd_client.py
+++ b/examples/bd_client.py
@@ -33,29 +33,15 @@ def recv_wrapper(s):
     r,w,e = select.select([s.fileno()],[],[], 2)
     if not r:
         return ''
-    #cols = int(s.recv(4))
-    #rows = int(s.recv(4))
     cols = 80
     rows = 24
     packet_size = cols * rows * 2 # double it for good measure
     return s.recv(packet_size)
 
-#HOST = '' #'localhost'    # The remote host
-#PORT = 1664 # The same port as used by the server
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-s.connect(sys.argv[1])#(HOST, PORT))
+s.connect(sys.argv[1])
 time.sleep(1)
-#s.setblocking(0)
-#s.send('COMMAND' + '\x01' + sys.argv[1])
 s.send(':sendline ' + sys.argv[2])
 print(recv_wrapper(s))
 s.close()
 sys.exit()
-#while True:
-#    data = recv_wrapper(s)
-#    if data == '':
-#        break
-#    sys.stdout.write (data)
-#    sys.stdout.flush()
-#s.close()
-

--- a/examples/cgishell.cgi
+++ b/examples/cgishell.cgi
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import sys,os
-sys.path.insert (0,os.getcwd()) # let local modules precede any installed modules
+sys.path.insert(0,os.getcwd()) # let local modules precede any installed modules
 import socket, random, string, traceback, cgi, time, getopt, getpass, threading, resource, signal
 import pxssh, pexpect, ANSI
 
@@ -28,7 +28,7 @@ def exit_with_usage(exit_code=1):
     print(globals()['__doc__'])
     os._exit(exit_code)
 
-def client (command, host='localhost', port=-1):
+def client(command, host='localhost', port=-1):
     """This sends a request to the server and returns the response.
     If port <= 0 then host is assumed to be the filename of a Unix domain socket.
     If port > 0 then host is an inet hostname.
@@ -40,11 +40,11 @@ def client (command, host='localhost', port=-1):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((host, port))
     s.send(command)
-    data = s.recv (2500)
+    data = s.recv(2500)
     s.close()
     return data
 
-def server (hostname, username, password, socket_filename='/tmp/server_sock', daemon_mode = True, verbose=False):
+def server(hostname, username, password, socket_filename='/tmp/server_sock', daemon_mode = True, verbose=False):
     """This starts and services requests from a client.
         If daemon_mode is True then this forks off a separate daemon process and returns the daemon's pid.
         If daemon_mode is False then this does not return until the server is done.
@@ -57,15 +57,15 @@ def server (hostname, username, password, socket_filename='/tmp/server_sock', da
             os.unlink(mypid_name)
             return daemon_pid
 
-    virtual_screen = ANSI.ANSI (24,80) 
+    virtual_screen = ANSI.ANSI(24,80)
     child = pxssh.pxssh()
     try:
-        child.login (hostname, username, password, login_naked=True)
+        child.login(hostname, username, password, login_naked=True)
     except:
-        return   
+        return
     if verbose: print('login OK')
-    virtual_screen.write (child.before)
-    virtual_screen.write (child.after)
+    virtual_screen.write(child.before)
+    virtual_screen.write(child.after)
 
     if os.path.exists(socket_filename): os.remove(socket_filename)
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -74,7 +74,7 @@ def server (hostname, username, password, socket_filename='/tmp/server_sock', da
     if verbose: print('Listen')
     s.listen(1)
 
-    r = roller (endless_poll, (child, child.PROMPT, virtual_screen))
+    r = roller(endless_poll, (child, child.PROMPT, virtual_screen))
     r.start()
     if verbose: print("started screen-poll-updater in background thread")
     sys.stdout.flush()
@@ -95,13 +95,13 @@ def server (hostname, username, password, socket_filename='/tmp/server_sock', da
                 r.cancel()
                 break
             elif cmd == 'sendline':
-                child.sendline (arg)
+                child.sendline(arg)
                 time.sleep(0.1)
                 shell_window = str(virtual_screen)
             elif cmd == 'send' or cmd=='xsend':
                 if cmd=='xsend':
                     arg = arg.decode("hex")
-                child.send (arg)
+                child.send(arg)
                 time.sleep(0.1)
                 shell_window = str(virtual_screen)
             elif cmd == 'cursor':
@@ -112,10 +112,10 @@ def server (hostname, username, password, socket_filename='/tmp/server_sock', da
                 shell_window = str(hash(str(virtual_screen)))
 
             response = []
-            response.append (shell_window)
+            response.append(shell_window)
             if verbose: print('\n'.join(response))
             sent = conn.send('\n'.join(response))
-            if sent < len (response):
+            if sent < len(response):
                 if verbose: print("Sent is too short. Some data was cut off.")
             conn.close()
     except e:
@@ -144,7 +144,7 @@ class roller (threading.Thread):
         while not self.finished.isSet():
             self.function(*self.args, **self.kwargs)
 
-def endless_poll (child, prompt, screen, refresh_timeout=0.1):
+def endless_poll(child, prompt, screen, refresh_timeout=0.1):
     """This keeps the screen updated with the output of the child.
         This will be run in a separate thread. See roller class.
     """
@@ -155,7 +155,7 @@ def endless_poll (child, prompt, screen, refresh_timeout=0.1):
     except:
         pass
 
-def daemonize (stdin=None, stdout=None, stderr=None, daemon_pid_filename=None):
+def daemonize(stdin=None, stdout=None, stderr=None, daemon_pid_filename=None):
     """This runs the current process in the background as a daemon.
     The arguments stdin, stdout, stderr allow you to set the filename that the daemon reads and writes to.
     If they are set to None then all stdio for the daemon will be directed to /dev/null.
@@ -209,7 +209,7 @@ def daemonize (stdin=None, stdout=None, stderr=None, daemon_pid_filename=None):
     maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
     if maxfd == resource.RLIM_INFINITY:
         maxfd = MAXFD
-  
+
     # close all file descriptors
     for fd in range(0, maxfd):
         try:
@@ -217,7 +217,7 @@ def daemonize (stdin=None, stdout=None, stderr=None, daemon_pid_filename=None):
         except OSError:   # fd wasn't open to begin with (ignored)
             pass
 
-    os.open (DEVNULL, os.O_RDWR)  # standard input
+    os.open(DEVNULL, os.O_RDWR)  # standard input
 
     # redirect standard file descriptors
     si = open(stdin, 'r')
@@ -229,7 +229,7 @@ def daemonize (stdin=None, stdout=None, stderr=None, daemon_pid_filename=None):
 
     return 0
 
-def client_cgi ():
+def client_cgi():
     """This handles the request if this script was called as a cgi.
     """
     sys.stderr = sys.stdout
@@ -247,23 +247,23 @@ def client_cgi ():
             if ajax_cmd == 'send':
                 command = 'xsend'
                 arg = form['arg'].value.encode('hex')
-                result = client (command + ' ' + arg, '/tmp/'+SID)
+                result = client(command + ' ' + arg, '/tmp/'+SID)
                 print(result)
             elif ajax_cmd == 'refresh':
                 command = 'refresh'
-                result = client (command, '/tmp/'+SID)
+                result = client(command, '/tmp/'+SID)
                 print(result)
             elif ajax_cmd == 'cursor':
                 command = 'cursor'
-                result = client (command, '/tmp/'+SID)
+                result = client(command, '/tmp/'+SID)
                 print(result)
             elif ajax_cmd == 'exit':
                 command = 'exit'
-                result = client (command, '/tmp/'+SID)
+                result = client(command, '/tmp/'+SID)
                 print(result)
             elif ajax_cmd == 'hash':
                 command = 'hash'
-                result = client (command, '/tmp/'+SID)
+                result = client(command, '/tmp/'+SID)
                 print(result)
         elif 'sid' not in form:
             SID=random_sid()
@@ -273,14 +273,14 @@ def client_cgi ():
             if 'start_server' in form:
                 USERNAME = form['username'].value
                 PASSWORD = form['password'].value
-                dpid = server ('127.0.0.1', USERNAME, PASSWORD, '/tmp/'+SID)
+                dpid = server('127.0.0.1', USERNAME, PASSWORD, '/tmp/'+SID)
                 SHELL_OUTPUT="daemon pid: " + str(dpid)
             else:
                 if 'cli' in form:
                     command = 'sendline ' + form['cli'].value
                 else:
                     command = 'sendline'
-                SHELL_OUTPUT = client (command, '/tmp/'+SID)
+                SHELL_OUTPUT = client(command, '/tmp/'+SID)
             print(CGISH_HTML % locals())
     except:
         tb_dump = traceback.format_exc()
@@ -306,7 +306,7 @@ def server_cli():
     # There are a million ways to cry for help. These are but a few of them.
     if [elem for elem in command_line_options if elem in ['-h','--h','-?','--?','--help']]:
         exit_with_usage(0)
-  
+
     hostname = "127.0.0.1"
     #port = 1664
     username = os.getenv('USER')
@@ -328,15 +328,15 @@ def server_cli():
         password = options['--password']
     else:
         password = getpass.getpass('password: ')
-   
-    server (hostname, username, password, '/tmp/mysock', daemon_mode)
 
-def random_sid ():
+    server(hostname, username, password, '/tmp/mysock', daemon_mode)
+
+def random_sid():
     a=random.randint(0,65535)
     b=random.randint(0,65535)
     return '%04x%04x.sid' % (a,b)
 
-def parse_host_connect_string (hcs):
+def parse_host_connect_string(hcs):
     """This parses a host connection string in the form
     username:password@hostname:port. All fields are options expcet hostname. A
     dictionary is returned with all four keys. Keys that were not included are
@@ -344,21 +344,21 @@ def parse_host_connect_string (hcs):
     then you must backslash escape it.
     """
     if '@' in hcs:
-        p = re.compile (r'(?P<username>[^@:]*)(:?)(?P<password>.*)(?!\\)@(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
+        p = re.compile(r'(?P<username>[^@:]*)(:?)(?P<password>.*)(?!\\)@(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
     else:
-        p = re.compile (r'(?P<username>)(?P<password>)(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
-    m = p.search (hcs)
+        p = re.compile(r'(?P<username>)(?P<password>)(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
+    m = p.search(hcs)
     d = m.groupdict()
     d['password'] = d['password'].replace('\\@','@')
     return d
-     
-def pretty_box (s, rows=24, cols=80):
+
+def pretty_box(s, rows=24, cols=80):
     """This puts an ASCII text box around the given string.
     """
     top_bot = '+' + '-'*cols + '+\n'
     return top_bot + '\n'.join(['|'+line+'|' for line in s.split('\n')]) + '\n' + top_bot
 
-def main ():
+def main():
     if os.getenv('REQUEST_METHOD') is None:
         server_cli()
     else:
@@ -376,8 +376,8 @@ a:hover {color: #0f0}
 hr {color: #0f0}
 html,body,textarea,input,form
 {
-font-family: "Courier New", Courier, mono; 
-font-size: 8pt; 
+font-family: "Courier New", Courier, mono;
+font-size: 8pt;
 color: #0c0;
 background-color: #020;
 margin:0;
@@ -455,7 +455,7 @@ function multibrowser_ajax ()
     return xmlHttp;
 }
 function load_url_to_screen(url)
-{ 
+{
     xmlhttp = multibrowser_ajax();
     //window.XMLHttpRequest?new XMLHttpRequest(): new ActiveXObject("Microsoft.XMLHTTP");
     xmlhttp.onreadystatechange = update_virtual_screen;
@@ -549,7 +549,7 @@ function key_shift()
         flag_shiftlock = 0;
         flag_shift = 1;
     }
-    update_button_colors(); 
+    update_button_colors();
 }
 function key_ctrl ()
 {
@@ -563,7 +563,7 @@ function key_ctrl ()
         flag_shiftlock = 0;
         flag_shift = 0;
     }
-    
+
     update_button_colors();
 }
 function update_button_colors ()
@@ -596,7 +596,7 @@ function update_button_colors ()
     {
         document.form['ShiftLock'].style.backgroundColor = document.form.style.backgroundColor;
     }
-    
+
 }
 function keyHandler(e)
 {
@@ -613,7 +613,7 @@ function keyHandler(e)
 //if (document.layers)
 //    document.captureEvents(Event.KEYPRESS);
 //http://sniptools.com/jskeys
-//document.onkeyup = KeyCheck;       
+//document.onkeyup = KeyCheck;
 function KeyCheck(e)
 {
     var KeyID = (window.event) ? event.keyCode : e.keyCode;
@@ -633,7 +633,7 @@ function KeyCheck(e)
 &nbsp;<input name="cli" id="cli" type="text" size="80"><br>
 <table border="0" align="left">
 <tr>
-<td width="86%%" align="center">    
+<td width="86%%" align="center">
     <input name="submit" type="submit" value="Submit">
     <input name="refresh" type="button" value="REFRESH" onclick="refresh_screen()">
     <input name="refresh" type="button" value="CURSOR" onclick="query_cursor()">
@@ -703,7 +703,7 @@ function KeyCheck(e)
     <input type="button" value="        FINAL FRONTIER        " onclick="type_key('  ')" />
 </td>
 </tr>
-</table>  
+</table>
 </form>
 </body>
 </html>
@@ -763,4 +763,3 @@ if __name__ == "__main__":
         print(str(e))
         tb_dump = traceback.format_exc()
         print(str(tb_dump))
-

--- a/examples/chess.py
+++ b/examples/chess.py
@@ -36,83 +36,83 @@ REGEX_MOVE_PART = '(?:[0-9]|\x1b\[C)(?:[a-z]|\x1b\[C)(?:[0-9]|\x1b\[C)'
 class Chess:
 
     def __init__(self, engine = "/usr/local/bin/gnuchess -a -h 1"):
-        self.child = pexpect.spawn (engine)
-        self.term = ANSI.ANSI ()
+        self.child = pexpect.spawn(engine)
+        self.term = ANSI.ANSI()
 
-        self.child.expect ('Chess')
+        self.child.expect('Chess')
         if self.child.after != 'Chess':
             raise IOError('incompatible chess program')
-        self.term.process_list (self.before)
-        self.term.process_list (self.after)
+        self.term.process_list(self.before)
+        self.term.process_list(self.after)
         self.last_computer_move = ''
 
-    def read_until_cursor (self, r,c):
+    def read_until_cursor(self, r,c):
         while 1:
             self.child.read(1, 60)
-            self.term.process (c)
+            self.term.process(c)
             if self.term.cur_r == r and self.term.cur_c == c:
                 return 1
 
-    def do_first_move (self, move):
-        self.child.expect ('Your move is')
-        self.child.sendline (move)
-        self.term.process_list (self.before)
-        self.term.process_list (self.after)
+    def do_first_move(self, move):
+        self.child.expect('Your move is')
+        self.child.sendline(move)
+        self.term.process_list(self.before)
+        self.term.process_list(self.after)
         return move
 
-    def do_move (self, move):
-        self.read_until_cursor (19,60)
-        self.child.sendline (move)
+    def do_move(self, move):
+        self.read_until_cursor(19,60)
+        self.child.sendline(move)
         return move
 
-    def get_first_computer_move (self):
-        self.child.expect ('My move is')
-        self.child.expect (REGEX_MOVE)
+    def get_first_computer_move(self):
+        self.child.expect('My move is')
+        self.child.expect(REGEX_MOVE)
         return self.child.after
 
-    def get_computer_move (self):
+    def get_computer_move(self):
         print('Here')
-        i = self.child.expect (['\[17;59H', '\[17;58H'])
+        i = self.child.expect(['\[17;59H', '\[17;58H'])
         print(i)
         if i == 0:
-            self.child.expect (REGEX_MOVE)
+            self.child.expect(REGEX_MOVE)
             if len(self.child.after) < 4:
                 self.child.after = self.child.after + self.last_computer_move[3]
         if i == 1:
-            self.child.expect (REGEX_MOVE_PART)
+            self.child.expect(REGEX_MOVE_PART)
             self.child.after = self.last_computer_move[0] + self.child.after
         print('', self.child.after)
         self.last_computer_move = self.child.after
         return self.child.after
 
-    def switch (self):
-        self.child.sendline ('switch')
+    def switch(self):
+        self.child.sendline('switch')
 
-    def set_depth (self, depth):
-        self.child.sendline ('depth')
-        self.child.expect ('depth=')
-        self.child.sendline ('%d' % depth)
+    def set_depth(self, depth):
+        self.child.sendline('depth')
+        self.child.expect('depth=')
+        self.child.sendline('%d' % depth)
 
     def quit(self):
-        self.child.sendline ('quit')
+        self.child.sendline('quit')
 import sys, os
 print('Starting...')
 white = Chess()
 white.child.echo = 1
-white.child.expect ('Your move is')
+white.child.expect('Your move is')
 white.set_depth(2)
 white.switch()
 
 move_white = white.get_first_computer_move()
 print('first move white:', move_white)
 
-white.do_move ('e7e5')
+white.do_move('e7e5')
 move_white = white.get_computer_move()
 print('move white:', move_white)
-white.do_move ('f8c5')
+white.do_move('f8c5')
 move_white = white.get_computer_move()
 print('move white:', move_white)
-white.do_move ('b8a6')
+white.do_move('b8a6')
 move_white = white.get_computer_move()
 print('move white:', move_white)
 
@@ -122,28 +122,28 @@ sys.exit(1)
 
 black = Chess()
 white = Chess()
-white.child.expect ('Your move is')
+white.child.expect('Your move is')
 white.switch()
 
 move_white = white.get_first_computer_move()
 print('first move white:', move_white)
 
-black.do_first_move (move_white)
+black.do_first_move(move_white)
 move_black = black.get_first_computer_move()
 print('first move black:', move_black)
 
-white.do_move (move_black)
+white.do_move(move_black)
 
 done = 0
 while not done:
     move_white = white.get_computer_move()
     print('move white:', move_white)
 
-    black.do_move (move_white)
+    black.do_move(move_white)
     move_black = black.get_computer_move()
     print('move black:', move_black)
 
-    white.do_move (move_black)
+    white.do_move(move_black)
     print('tail of loop')
 
 g.quit()

--- a/examples/chess2.py
+++ b/examples/chess2.py
@@ -34,8 +34,8 @@ import sys, os, time
 class Chess:
 
         def __init__(self, engine = "/usr/local/bin/gnuchess -a -h 1"):
-                self.child = pexpect.spawn (engine)
-                self.term = ANSI.ANSI ()
+                self.child = pexpect.spawn(engine)
+                self.term = ANSI.ANSI()
 
                 #self.child.expect ('Chess')
                 #if self.child.after != 'Chess':
@@ -45,22 +45,22 @@ class Chess:
 
                 self.last_computer_move = ''
 
-        def read_until_cursor (self, r,c, e=0):
+        def read_until_cursor(self, r,c, e=0):
             '''Eventually something like this should move into the screen class or
             a subclass. Maybe a combination of pexpect and screen...
             '''
-            fout = open ('log','a')
+            fout = open('log','a')
             while self.term.cur_r != r or self.term.cur_c != c:
                 try:
                     k = self.child.read(1, 10)
                 except Exception as e:
                     print('EXCEPTION, (r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
                     sys.stdout.flush()
-                self.term.process (k)
-                fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+                self.term.process(k)
+                fout.write('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
                 fout.flush()
                 if e:
-                    sys.stdout.write (k)
+                    sys.stdout.write(k)
                     sys.stdout.flush()
                 if self.term.cur_r == r and self.term.cur_c == c:
                     fout.close()
@@ -69,85 +69,83 @@ class Chess:
             fout.close()
             return 1
 
-        def expect_region (self):
+        def expect_region(self):
             '''This is another method that would be moved into the
             screen class.
             '''
             pass
-        def do_scan (self):
-            fout = open ('log','a')
+        def do_scan(self):
+            fout = open('log','a')
             while 1:
                 c = self.child.read(1,10)
-                self.term.process (c)
-                fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+                self.term.process(c)
+                fout.write('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
                 fout.flush()
-                sys.stdout.write (c)
+                sys.stdout.write(c)
                 sys.stdout.flush()
 
-        def do_move (self, move, e = 0):
+        def do_move(self, move, e = 0):
                 time.sleep(1)
-                self.read_until_cursor (19,60, e)
-                self.child.sendline (move)
+                self.read_until_cursor(19,60, e)
+                self.child.sendline(move)
 
-        def wait (self, color):
+        def wait(self, color):
             while 1:
-                r = self.term.get_region (14,50,14,60)[0]
+                r = self.term.get_region(14,50,14,60)[0]
                 r = r.strip()
                 if r == color:
                     return
-                time.sleep (1)
+                time.sleep(1)
 
-        def parse_computer_move (self, s):
-                i = s.find ('is: ')
+        def parse_computer_move(self, s):
+                i = s.find('is: ')
                 cm = s[i+3:i+9]
                 return cm
-        def get_computer_move (self, e = 0):
+        def get_computer_move(self, e = 0):
                 time.sleep(1)
-                self.read_until_cursor (19,60, e)
+                self.read_until_cursor(19,60, e)
                 time.sleep(1)
-                r = self.term.get_region (17,50,17,62)[0]
-                cm = self.parse_computer_move (r)
+                r = self.term.get_region(17,50,17,62)[0]
+                cm = self.parse_computer_move(r)
                 return cm
 
-        def switch (self):
+        def switch(self):
                 print('switching')
-                self.child.sendline ('switch')
+                self.child.sendline('switch')
 
-        def set_depth (self, depth):
-                self.child.sendline ('depth')
-                self.child.expect ('depth=')
-                self.child.sendline ('%d' % depth)
+        def set_depth(self, depth):
+                self.child.sendline('depth')
+                self.child.expect('depth=')
+                self.child.sendline('%d' % depth)
 
         def quit(self):
-                self.child.sendline ('quit')
+                self.child.sendline('quit')
 
-def LOG (s):
+def LOG(s):
     print(s)
-    sys.stdout.flush ()
-    fout = open ('moves.log', 'a')
-    fout.write (s + '\n')
+    sys.stdout.flush()
+    fout = open('moves.log', 'a')
+    fout.write(s + '\n')
     fout.close()
 
 print('Starting...')
 
 black = Chess()
 white = Chess()
-white.read_until_cursor (19,60,1)
+white.read_until_cursor(19,60,1)
 white.switch()
 
 done = 0
 while not done:
-    white.wait ('Black')
+    white.wait('Black')
     move_white = white.get_computer_move(1)
-    LOG ( 'move white:'+ move_white )
+    LOG('move white:'+ move_white)
 
-    black.do_move (move_white)
-    black.wait ('White')
+    black.do_move(move_white)
+    black.wait('White')
     move_black = black.get_computer_move()
-    LOG ( 'move black:'+ move_black )
+    LOG('move black:'+ move_black)
 
-    white.do_move (move_black, 1)
+    white.do_move(move_black, 1)
 
 g.quit()
-
-

--- a/examples/chess3.py
+++ b/examples/chess3.py
@@ -36,8 +36,8 @@ REGEX_MOVE_PART = '(?:[0-9]|\x1b\[C)(?:[a-z]|\x1b\[C)(?:[0-9]|\x1b\[C)'
 class Chess:
 
     def __init__(self, engine = "/usr/local/bin/gnuchess -a -h 1"):
-        self.child = pexpect.spawn (engine)
-        self.term = ANSI.ANSI ()
+        self.child = pexpect.spawn(engine)
+        self.term = ANSI.ANSI()
 
 #		self.child.expect ('Chess')
     #	if self.child.after != 'Chess':
@@ -45,81 +45,81 @@ class Chess:
     #        self.term.process_list (self.before)
     #        self.term.process_list (self.after)
         self.last_computer_move = ''
-    def read_until_cursor (self, r,c):
-        fout = open ('log','a')
+    def read_until_cursor(self, r,c):
+        fout = open('log','a')
         while 1:
             k = self.child.read(1, 10)
-            self.term.process (k)
-            fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+            self.term.process(k)
+            fout.write('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
             fout.flush()
             if self.term.cur_r == r and self.term.cur_c == c:
                 fout.close()
                 return 1
-            sys.stdout.write (k)
+            sys.stdout.write(k)
             sys.stdout.flush()
 
-    def do_scan (self):
-        fout = open ('log','a')
+    def do_scan(self):
+        fout = open('log','a')
         while 1:
             c = self.child.read(1,10)
-            self.term.process (c)
-            fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+            self.term.process(c)
+            fout.write('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
             fout.flush()
-            sys.stdout.write (c)
+            sys.stdout.write(c)
             sys.stdout.flush()
 
-    def do_move (self, move):
-        self.read_until_cursor (19,60)
-        self.child.sendline (move)
+    def do_move(self, move):
+        self.read_until_cursor(19,60)
+        self.child.sendline(move)
         return move
 
-    def get_computer_move (self):
+    def get_computer_move(self):
         print('Here')
-        i = self.child.expect (['\[17;59H', '\[17;58H'])
+        i = self.child.expect(['\[17;59H', '\[17;58H'])
         print(i)
         if i == 0:
-            self.child.expect (REGEX_MOVE)
+            self.child.expect(REGEX_MOVE)
             if len(self.child.after) < 4:
                 self.child.after = self.child.after + self.last_computer_move[3]
         if i == 1:
-            self.child.expect (REGEX_MOVE_PART)
+            self.child.expect(REGEX_MOVE_PART)
             self.child.after = self.last_computer_move[0] + self.child.after
         print('', self.child.after)
         self.last_computer_move = self.child.after
         return self.child.after
 
-    def switch (self):
-        self.child.sendline ('switch')
+    def switch(self):
+        self.child.sendline('switch')
 
-    def set_depth (self, depth):
-        self.child.sendline ('depth')
-        self.child.expect ('depth=')
-        self.child.sendline ('%d' % depth)
+    def set_depth(self, depth):
+        self.child.sendline('depth')
+        self.child.expect('depth=')
+        self.child.sendline('%d' % depth)
 
     def quit(self):
-        self.child.sendline ('quit')
+        self.child.sendline('quit')
 import sys, os
 print('Starting...')
 white = Chess()
 white.do_move('b2b4')
-white.read_until_cursor (19,60)
+white.read_until_cursor(19,60)
 c1 = white.term.get_abs(17,58)
 c2 = white.term.get_abs(17,59)
 c3 = white.term.get_abs(17,60)
 c4 = white.term.get_abs(17,61)
-fout = open ('log','a')
-fout.write ('Computer:%s%s%s%s\n' %(c1,c2,c3,c4))
+fout = open('log','a')
+fout.write('Computer:%s%s%s%s\n' %(c1,c2,c3,c4))
 fout.close()
 white.do_move('c2c4')
-white.read_until_cursor (19,60)
+white.read_until_cursor(19,60)
 c1 = white.term.get_abs(17,58)
 c2 = white.term.get_abs(17,59)
 c3 = white.term.get_abs(17,60)
 c4 = white.term.get_abs(17,61)
-fout = open ('log','a')
-fout.write ('Computer:%s%s%s%s\n' %(c1,c2,c3,c4))
+fout = open('log','a')
+fout.write('Computer:%s%s%s%s\n' %(c1,c2,c3,c4))
 fout.close()
-white.do_scan ()
+white.do_scan()
 
 #white.do_move ('b8a6')
 #move_white = white.get_computer_move()
@@ -131,28 +131,28 @@ sys.exit(1)
 
 black = Chess()
 white = Chess()
-white.child.expect ('Your move is')
+white.child.expect('Your move is')
 white.switch()
 
 move_white = white.get_first_computer_move()
 print('first move white:', move_white)
 
-black.do_first_move (move_white)
+black.do_first_move(move_white)
 move_black = black.get_first_computer_move()
 print('first move black:', move_black)
 
-white.do_move (move_black)
+white.do_move(move_black)
 
 done = 0
 while not done:
     move_white = white.get_computer_move()
     print('move white:', move_white)
 
-    black.do_move (move_white)
+    black.do_move(move_white)
     move_black = black.get_computer_move()
     print('move black:', move_black)
 
-    white.do_move (move_black)
+    white.do_move(move_black)
     print('tail of loop')
 
 g.quit()

--- a/examples/df.py
+++ b/examples/df.py
@@ -32,15 +32,15 @@ from __future__ import absolute_import
 
 import pexpect
 
-child = pexpect.spawn ('df')
+child = pexpect.spawn('df')
 
 # parse 'df' output into a list.
 pattern = "\n(\S+).*?([0-9]+)%"
 filesystem_list = []
-for dummy in range (0, 1000):
-    i = child.expect ([pattern, pexpect.EOF])
+for dummy in range(0, 1000):
+    i = child.expect([pattern, pexpect.EOF])
     if i == 0:
-        filesystem_list.append (child.match.groups())
+        filesystem_list.append(child.match.groups())
     else:
         break
 
@@ -54,4 +54,3 @@ for m in filesystem_list:
     else:
         s = '  ' + s
     print(s)
-

--- a/examples/fix_cvs_files.py
+++ b/examples/fix_cvs_files.py
@@ -43,7 +43,7 @@ import pexpect
 
 VERBOSE = 1
 
-def is_binary (filename):
+def is_binary(filename):
 
     '''Assume that any file with a character where the 8th bit is set is
     binary. '''
@@ -56,15 +56,15 @@ def is_binary (filename):
             return 1
     return 0
 
-def is_kb_sticky (filename):
+def is_kb_sticky(filename):
 
     '''This checks if 'cvs status' reports '-kb' for Sticky options. If the
     Sticky Option status is '-ks' then this returns 1. If the status is
     'Unknown' then it returns 1. Otherwise 0 is returned. '''
 
     try:
-        s = pexpect.spawn ('cvs status %s' % filename)
-        i = s.expect (['Sticky Options:\s*(.*)\r\n',  'Status: Unknown'])
+        s = pexpect.spawn('cvs status %s' % filename)
+        i = s.expect(['Sticky Options:\s*(.*)\r\n',  'Status: Unknown'])
         if i==1 and VERBOSE:
             print('File not part of CVS repository:', filename)
             return 1 # Pretend it's OK.
@@ -78,16 +78,16 @@ def is_kb_sticky (filename):
         print(s.before)
     return 0
 
-def cvs_admin_kb (filename):
+def cvs_admin_kb(filename):
 
     '''This uses 'cvs admin' to set the '-kb' sticky option. '''
 
-    s = pexpect.run ('cvs admin -kb %s' % filename)
+    s = pexpect.run('cvs admin -kb %s' % filename)
     # There is a timing issue. If I run 'cvs admin' too quickly
     # cvs sometimes has trouble obtaining the directory lock.
     time.sleep(1)
 
-def walk_and_clean_cvs_binaries (arg, dirname, names):
+def walk_and_clean_cvs_binaries(arg, dirname, names):
 
     '''This contains the logic for processing files. This is the os.path.walk
     callback. This skips dirnames that end in CVS. '''
@@ -95,21 +95,21 @@ def walk_and_clean_cvs_binaries (arg, dirname, names):
     if len(dirname)>3 and dirname[-3:]=='CVS':
         return
     for n in names:
-        fullpath = os.path.join (dirname, n)
+        fullpath = os.path.join(dirname, n)
         if os.path.isdir(fullpath) or os.path.islink(fullpath):
             continue
         if is_binary(fullpath):
-            if not is_kb_sticky (fullpath):
+            if not is_kb_sticky(fullpath):
                 if VERBOSE: print(fullpath)
-                cvs_admin_kb (fullpath)
+                cvs_admin_kb(fullpath)
 
-def main ():
+def main():
 
     if len(sys.argv) == 1:
         root = '.'
     else:
         root = sys.argv[1]
-    os.path.walk (root, walk_and_clean_cvs_binaries, None)
+    os.path.walk(root, walk_and_clean_cvs_binaries, None)
 
 if __name__ == '__main__':
-    main ()
+    main()

--- a/examples/ftp.py
+++ b/examples/ftp.py
@@ -50,7 +50,7 @@ child.expect('ftp> ')
 child.sendline('pwd')
 child.expect('ftp> ')
 print("Escape character is '^]'.\n")
-sys.stdout.write (child.after)
+sys.stdout.write(child.after)
 sys.stdout.flush()
 child.interact() # Escape character defaults to ^]
 # At this point this script blocks until the user presses the escape character
@@ -70,4 +70,3 @@ if child.isalive():
     print('Child did not exit gracefully.')
 else:
     print('Child exited gracefully.')
-

--- a/examples/hive.py
+++ b/examples/hive.py
@@ -186,7 +186,7 @@ CMD_HELP='''Hive commands are preceded by a colon : (just think of vi).
 
 '''
 
-def login (args, cli_username=None, cli_password=None):
+def login(args, cli_username=None, cli_password=None):
 
     # I have to keep a separate list of host names because Python dicts are not ordered.
     # I want to keep the same order as in the args list.
@@ -195,7 +195,7 @@ def login (args, cli_username=None, cli_password=None):
     hive = {}
     # build up the list of connection information (hostname, username, password, port)
     for host_connect_string in args:
-        hcd = parse_host_connect_string (host_connect_string)
+        hcd = parse_host_connect_string(host_connect_string)
         hostname = hcd['hostname']
         port     = hcd['port']
         if port == '':
@@ -236,7 +236,7 @@ def login (args, cli_username=None, cli_password=None):
             hive[hostname] = None
     return host_names, hive
 
-def main ():
+def main():
 
     global options, args, CMD_HELP
 
@@ -265,7 +265,7 @@ def main ():
             print(CMD_HELP)
             continue
         elif cmd==':refresh':
-            refresh (hive, target_hostnames, timeout=0.5)
+            refresh(hive, target_hostnames, timeout=0.5)
             for hostname in target_hostnames:
                 print('/' + '=' * (cols - 2))
                 print('| ' + hostname)
@@ -277,7 +277,7 @@ def main ():
             print('#' * 79)
             continue
         elif cmd==':resync':
-            resync (hive, target_hostnames, timeout=0.5)
+            resync(hive, target_hostnames, timeout=0.5)
             for hostname in target_hostnames:
                 print('/' + '=' * (cols - 2))
                 print('| ' + hostname)
@@ -290,7 +290,7 @@ def main ():
             continue
         elif cmd==':sync':
             synchronous_mode = True
-            resync (hive, target_hostnames, timeout=0.5)
+            resync(hive, target_hostnames, timeout=0.5)
             continue
         elif cmd==':async':
             synchronous_mode = False
@@ -325,7 +325,7 @@ def main ():
                 print('# DEAD: %s' % hostname)
                 continue
             try:
-                hive[hostname].sendline (txt)
+                hive[hostname].sendline(txt)
                 hive[hostname].prompt(timeout=2)
                 print(hive[hostname].before)
             except Exception as e:
@@ -354,7 +354,7 @@ def main ():
             continue
         elif cmd == ':exit' or cmd == ':q' or cmd == ':quit':
             break
-        elif cmd[:8] == ':control' or cmd[:5] == ':ctrl' :
+        elif cmd[:8] == ':control' or cmd[:5] == ':ctrl':
             cmd, c = cmd.split(None,1)
             if ord(c)-96 < 0 or ord(c)-96 > 255:
                 print('/' + '=' * (cols - 2))
@@ -381,7 +381,7 @@ def main ():
         for hostname in target_hostnames:
             try:
                 if hive[hostname] is not None:
-                    hive[hostname].sendline (cmd)
+                    hive[hostname].sendline(cmd)
             except Exception as e:
                 print("Had trouble communicating with %s, so removing it from the target list." % hostname)
                 print(str(e))
@@ -407,7 +407,7 @@ def main ():
                     hive[hostname] = None
             print('#' * 79)
 
-def refresh (hive, hive_names, timeout=0.5):
+def refresh(hive, hive_names, timeout=0.5):
 
     '''This waits for the TIMEOUT on each host.
     '''
@@ -417,7 +417,7 @@ def refresh (hive, hive_names, timeout=0.5):
         if hive[hostname] is not None:
             hive[hostname].expect([pexpect.TIMEOUT,pexpect.EOF],timeout=timeout)
 
-def resync (hive, hive_names, timeout=2, max_attempts=5):
+def resync(hive, hive_names, timeout=2, max_attempts=5):
 
     '''This waits for the shell prompt for each host in an effort to try to get
     them all to the same state. The timeout is set low so that hosts that are
@@ -435,7 +435,7 @@ def resync (hive, hive_names, timeout=2, max_attempts=5):
                 if not hive[hostname].prompt(timeout=timeout):
                     break
 
-def parse_host_connect_string (hcs):
+def parse_host_connect_string(hcs):
 
     '''This parses a host connection string in the form
     username:password@hostname:port. All fields are options expcet hostname. A
@@ -444,10 +444,10 @@ def parse_host_connect_string (hcs):
     then you must backslash escape it. '''
 
     if '@' in hcs:
-        p = re.compile (r'(?P<username>[^@:]*)(:?)(?P<password>.*)(?!\\)@(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
+        p = re.compile(r'(?P<username>[^@:]*)(:?)(?P<password>.*)(?!\\)@(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
     else:
-        p = re.compile (r'(?P<username>)(?P<password>)(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
-    m = p.search (hcs)
+        p = re.compile(r'(?P<username>)(?P<password>)(?P<hostname>[^:]*):?(?P<port>[0-9]*)')
+    m = p.search(hcs)
     d = m.groupdict()
     d['password'] = d['password'].replace('\\@','@')
     return d
@@ -456,12 +456,12 @@ if __name__ == '__main__':
     try:
         start_time = time.time()
         parser = optparse.OptionParser(formatter=optparse.TitledHelpFormatter(), usage=globals()['__doc__'], version='$Id: hive.py 533 2012-10-20 02:19:33Z noah $',conflict_handler="resolve")
-        parser.add_option ('-v', '--verbose', action='store_true', default=False, help='verbose output')
-        parser.add_option ('--samepass', action='store_true', default=False, help='Use same password for each login.')
-        parser.add_option ('--sameuser', action='store_true', default=False, help='Use same username for each login.')
+        parser.add_option('-v', '--verbose', action='store_true', default=False, help='verbose output')
+        parser.add_option('--samepass', action='store_true', default=False, help='Use same password for each login.')
+        parser.add_option('--sameuser', action='store_true', default=False, help='Use same username for each login.')
         (options, args) = parser.parse_args()
         if len(args) < 1:
-            parser.error ('missing argument')
+            parser.error('missing argument')
         if options.verbose: print(time.asctime())
         main()
         if options.verbose: print(time.asctime())

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -111,10 +111,10 @@ def main():
         print('ERROR! could not login with SSH. Here is what SSH said:')
         print(child.before, child.after)
         print(str(child))
-        sys.exit (1)
+        sys.exit(1)
     if i == 1: # In this case SSH does not have the public key cached.
-        child.sendline ('yes')
-        child.expect ('(?i)password')
+        child.sendline('yes')
+        child.expect('(?i)password')
     if i == 2:
         # This may happen if a public key was setup to automatically login.
         # But beware, the COMMAND_PROMPT at this point is very trivial and
@@ -124,25 +124,25 @@ def main():
         child.sendline(password)
         # Now we are either at the command prompt or
         # the login process is asking for our terminal type.
-        i = child.expect ([COMMAND_PROMPT, TERMINAL_PROMPT])
+        i = child.expect([COMMAND_PROMPT, TERMINAL_PROMPT])
         if i == 1:
-            child.sendline (TERMINAL_TYPE)
-            child.expect (COMMAND_PROMPT)
+            child.sendline(TERMINAL_TYPE)
+            child.expect(COMMAND_PROMPT)
     #
     # Set command prompt to something more unique.
     #
     COMMAND_PROMPT = "\[PEXPECT\]\$ "
-    child.sendline ("PS1='[PEXPECT]\$ '") # In case of sh-style
-    i = child.expect ([pexpect.TIMEOUT, COMMAND_PROMPT], timeout=10)
+    child.sendline("PS1='[PEXPECT]\$ '") # In case of sh-style
+    i = child.expect([pexpect.TIMEOUT, COMMAND_PROMPT], timeout=10)
     if i == 0:
         print("# Couldn't set sh-style prompt -- trying csh-style.")
-        child.sendline ("set prompt='[PEXPECT]\$ '")
-        i = child.expect ([pexpect.TIMEOUT, COMMAND_PROMPT], timeout=10)
+        child.sendline("set prompt='[PEXPECT]\$ '")
+        i = child.expect([pexpect.TIMEOUT, COMMAND_PROMPT], timeout=10)
         if i == 0:
             print("Failed to set command prompt using sh or csh style.")
             print("Response was:")
             print(child.before)
-            sys.exit (1)
+            sys.exit(1)
 
     # Now we should be at the command prompt and ready to run some commands.
     print('---------------------------------------')
@@ -150,8 +150,8 @@ def main():
     print('---------------------------------------')
 
     # Run uname.
-    child.sendline ('uname -a')
-    child.expect (COMMAND_PROMPT)
+    child.sendline('uname -a')
+    child.expect(COMMAND_PROMPT)
     print(child.before)
     if 'linux' in child.before.lower():
         LINUX_MODE = 1
@@ -159,7 +159,7 @@ def main():
         LINUX_MODE = 0
 
     # Run and parse 'uptime'.
-    child.sendline ('uptime')
+    child.sendline('uptime')
     child.expect('up\s+(.*?),\s+([0-9]+) users?,\s+load averages?: ([0-9]+\.[0-9][0-9]),?\s+([0-9]+\.[0-9][0-9]),?\s+([0-9]+\.[0-9][0-9])')
     duration, users, av1, av5, av15 = child.match.groups()
     days = '0'
@@ -178,32 +178,32 @@ def main():
     print()
     print('Uptime: %s days, %s users, %s (1 min), %s (5 min), %s (15 min)' % (
         duration, users, av1, av5, av15))
-    child.expect (COMMAND_PROMPT)
+    child.expect(COMMAND_PROMPT)
 
     # Run iostat.
-    child.sendline ('iostat')
-    child.expect (COMMAND_PROMPT)
+    child.sendline('iostat')
+    child.expect(COMMAND_PROMPT)
     print(child.before)
 
     # Run vmstat.
-    child.sendline ('vmstat')
-    child.expect (COMMAND_PROMPT)
+    child.sendline('vmstat')
+    child.expect(COMMAND_PROMPT)
     print(child.before)
 
     # Run free.
     if LINUX_MODE:
-        child.sendline ('free') # Linux systems only.
-        child.expect (COMMAND_PROMPT)
+        child.sendline('free') # Linux systems only.
+        child.expect(COMMAND_PROMPT)
         print(child.before)
 
     # Run df.
-    child.sendline ('df')
-    child.expect (COMMAND_PROMPT)
+    child.sendline('df')
+    child.expect(COMMAND_PROMPT)
     print(child.before)
 
     # Run lsof.
-    child.sendline ('lsof')
-    child.expect (COMMAND_PROMPT)
+    child.sendline('lsof')
+    child.expect(COMMAND_PROMPT)
     print(child.before)
 
 #    # Run netstat
@@ -220,7 +220,7 @@ def main():
 #    print child.before
 
     # Now exit the remote host.
-    child.sendline ('exit')
+    child.sendline('exit')
     index = child.expect([pexpect.EOF, "(?i)there are stopped jobs"])
     if index==1:
         child.sendline("exit")
@@ -234,4 +234,3 @@ if __name__ == "__main__":
         print(str(e))
         traceback.print_exc()
         os._exit(1)
-

--- a/examples/passmass.py
+++ b/examples/passmass.py
@@ -45,28 +45,28 @@ SSH_NEWKEY = r'Are you sure you want to continue connecting \(yes/no\)\?'
 def login(host, user, password):
 
     child = pexpect.spawn('ssh -l %s %s'%(user, host))
-    fout = file ("LOG.TXT","wb")
-    child.setlog (fout)
+    fout = file("LOG.TXT","wb")
+    child.setlog(fout)
 
     i = child.expect([pexpect.TIMEOUT, SSH_NEWKEY, '[Pp]assword: '])
     if i == 0: # Timeout
         print('ERROR!')
         print('SSH could not login. Here is what SSH said:')
         print(child.before, child.after)
-        sys.exit (1)
+        sys.exit(1)
     if i == 1: # SSH does not have the public key. Just accept it.
-        child.sendline ('yes')
-        child.expect ('[Pp]assword: ')
+        child.sendline('yes')
+        child.expect('[Pp]assword: ')
     child.sendline(password)
     # Now we are either at the command prompt or
     # the login process is asking for our terminal type.
-    i = child.expect (['Permission denied', TERMINAL_PROMPT, COMMAND_PROMPT])
+    i = child.expect(['Permission denied', TERMINAL_PROMPT, COMMAND_PROMPT])
     if i == 0:
         print('Permission denied on host:', host)
-        sys.exit (1)
+        sys.exit(1)
     if i == 1:
-        child.sendline (TERMINAL_TYPE)
-        child.expect (COMMAND_PROMPT)
+        child.sendline(TERMINAL_TYPE)
+        child.expect(COMMAND_PROMPT)
     return child
 
 # (current) UNIX password:
@@ -83,7 +83,7 @@ def change_password(child, user, oldpassword, newpassword):
     if i == 0:
         print('Host did not like new password. Here is what it said...')
         print(child.before)
-        child.send (chr(3)) # Ctrl-C
+        child.send(chr(3)) # Ctrl-C
         child.sendline('') # This should tell remote passwd command to quit.
         return
     child.sendline(newpassword)

--- a/examples/python.py
+++ b/examples/python.py
@@ -46,4 +46,3 @@ print(c.after, end=' ')
 c.interact()
 c.kill(1)
 print('is alive:', c.isalive())
-

--- a/examples/rippy.py
+++ b/examples/rippy.py
@@ -83,7 +83,7 @@ __revision__ = '$Revision: 11 $'
 __all__ = ['main', __version__, __revision__]
 
 GLOBAL_LOGFILE_NAME = "rippy_%d.log" % os.getpid()
-GLOBAL_LOGFILE = open (GLOBAL_LOGFILE_NAME, "wb")
+GLOBAL_LOGFILE = open(GLOBAL_LOGFILE_NAME, "wb")
 
 ###############################################################################
 # This giant section defines the prompts and defaults used in interactive mode.
@@ -220,7 +220,7 @@ Values of 6 to 10 usually adjust quiet DVDs to a comfortable level.''',1),
 ##############################################################################
 # This is the important convert control function
 ##############################################################################
-def convert (options):
+def convert(options):
     '''This is the heart of it all -- this performs an end-to-end conversion of
     a video from one format to another. It requires a dictionary of options.
     The conversion process will also add some keys to the dictionary
@@ -230,7 +230,7 @@ def convert (options):
     '''
     if options['subtitle_id'] is not None:
         print("# extract subtitles")
-        apply_smart (extract_subtitles, options)
+        apply_smart(extract_subtitles, options)
     else:
         print("# do not extract subtitles.")
 
@@ -246,38 +246,38 @@ def convert (options):
         # you cannot get exact time based on compressed size.
         if options['video_length']=='calc':
             print("# extract PCM raw audio to %s" % (options['audio_raw_filename']))
-            apply_smart (extract_audio, options)
-            options['video_length'] = apply_smart (get_length, options)
+            apply_smart(extract_audio, options)
+            options['video_length'] = apply_smart(get_length, options)
             print("# Length of raw audio file : %d seconds (%0.2f minutes)" % (options['video_length'], float(options['video_length'])/60.0))
         if options['video_bitrate']=='calc':
-            options['video_bitrate'] = options['video_bitrate_overhead'] * apply_smart (calc_video_bitrate, options)
+            options['video_bitrate'] = options['video_bitrate_overhead'] * apply_smart(calc_video_bitrate, options)
         print("# video bitrate : " + str(options['video_bitrate']))
         if options['video_crop_area']=='detect':
-            options['video_crop_area'] = apply_smart (crop_detect, options)
+            options['video_crop_area'] = apply_smart(crop_detect, options)
         print("# crop area : " + str(options['video_crop_area']))
         print("# compression estimate")
-        print(apply_smart (compression_estimate, options))
+        print(apply_smart(compression_estimate, options))
 
     print("# compress video")
-    apply_smart (compress_video, options)
+    apply_smart(compress_video, options)
     'audio_volume_boost',
 
     print("# delete temporary files:", end=' ')
     if options['delete_tmp_files_flag']:
         print("yes")
-        apply_smart (delete_tmp_files, options)
+        apply_smart(delete_tmp_files, options)
     else:
         print("no")
 
     # Finish by saving options to rippy.conf and
     # calclating if final_size is less than target_size.
     o = ["# options used to create video\n"]
-    video_actual_size = get_filesize (options['video_final_filename'])
+    video_actual_size = get_filesize(options['video_final_filename'])
     if options['video_target_size'] != 'none':
-        revised_bitrate = calculate_revised_bitrate (options['video_bitrate'], options['video_target_size'], video_actual_size)
+        revised_bitrate = calculate_revised_bitrate(options['video_bitrate'], options['video_target_size'], video_actual_size)
         o.append("# revised video_bitrate : %d\n" % revised_bitrate)
     for k,v in options.items():
-        o.append (" %30s : %s\n" % (k, v))
+        o.append(" %30s : %s\n" % (k, v))
     print('# '.join(o))
     fout = open("rippy.conf","wb").write(''.join(o))
     print("# final actual video size = %d" % video_actual_size)
@@ -301,7 +301,7 @@ def exit_with_usage(exit_code=1):
     sys.stdout.flush()
     os._exit(exit_code)
 
-def check_missing_requirements ():
+def check_missing_requirements():
     '''This list of missing requirements (mencoder, mplayer, lame, and mkvmerge).
     Returns None if all requirements are in the execution path.
     '''
@@ -324,7 +324,7 @@ def check_missing_requirements ():
         return None
     return missing
 
-def input_option (message, default_value="", help=None, level=0, max_level=0):
+def input_option(message, default_value="", help=None, level=0, max_level=0):
     '''This is a fancy raw_input function.
     If the user enters '?' then the contents of help is printed.
 
@@ -340,7 +340,7 @@ def input_option (message, default_value="", help=None, level=0, max_level=0):
     if level > max_level:
         return default_value
     while 1:
-        user_input = raw_input (message)
+        user_input = raw_input(message)
         if user_input=='?':
             print(help)
         elif user_input=='':
@@ -349,11 +349,11 @@ def input_option (message, default_value="", help=None, level=0, max_level=0):
             break
     return user_input
 
-def progress_callback (d=None):
+def progress_callback(d=None):
     '''This callback simply prints a dot to show activity.
     This is used when running external commands with pexpect.run.
     '''
-    sys.stdout.write (".")
+    sys.stdout.write(".")
     sys.stdout.flush()
 
 def run(cmd):
@@ -365,7 +365,7 @@ def run(cmd):
         print("RUN FAILED. RETURNED EXIT STATUS:", exitstatus, file=GLOBAL_LOGFILE)
     return (command_output, exitstatus)
 
-def apply_smart (func, args):
+def apply_smart(func, args):
     '''This is similar to func(**args), but this won't complain about
     extra keys in 'args'. This ignores keys in 'args' that are
     not required by 'func'. This passes None to arguments that are
@@ -385,7 +385,7 @@ def apply_smart (func, args):
     required_args = dict([(k,args.get(k)) for k in func.__code__.co_varnames[:argcount]])
     return func(**required_args)
 
-def count_unique (items):
+def count_unique(items):
     '''This takes a list and returns a sorted list of tuples with a count of each unique item in the list.
     Example 1:
         count_unique(['a','b','c','a','c','c','a','c','c'])
@@ -407,7 +407,7 @@ def count_unique (items):
     stats.reverse()
     return stats
 
-def calculate_revised_bitrate (video_bitrate, video_target_size, video_actual_size):
+def calculate_revised_bitrate(video_bitrate, video_target_size, video_actual_size):
     '''This calculates a revised video bitrate given the video_bitrate used,
     the actual size that resulted, and the video_target_size.
     This can be used if you want to compress the video all over again in an
@@ -415,7 +415,7 @@ def calculate_revised_bitrate (video_bitrate, video_target_size, video_actual_si
     '''
     return int(math.floor(video_bitrate * (float(video_target_size) / float(video_actual_size))))
 
-def get_aspect_ratio (video_source_filename):
+def get_aspect_ratio(video_source_filename):
     '''This returns the aspect ratio of the original video.
     This is usualy 1.78:1(16/9) or 1.33:1(4/3).
     This function is very lenient. It basically guesses 16/9 whenever
@@ -442,7 +442,7 @@ def get_aspect_ratio (video_source_filename):
 #Movie-Aspect is 1.78:1 - prescaling to correct movie aspect.
 
 
-def get_aid_list (video_source_filename):
+def get_aid_list(video_source_filename):
     '''This returns a list of audio ids in the source video file.
     TODO: Also extract ID_AID_nnn_LANG to associate language. Not all DVDs include this.
     '''
@@ -452,7 +452,7 @@ def get_aid_list (video_source_filename):
     idl.sort()
     return idl
 
-def get_sid_list (video_source_filename):
+def get_sid_list(video_source_filename):
     '''This returns a list of subtitle ids in the source video file.
     TODO: Also extract ID_SID_nnn_LANG to associate language. Not all DVDs include this.
     '''
@@ -462,7 +462,7 @@ def get_sid_list (video_source_filename):
     idl.sort()
     return idl
 
-def extract_audio (video_source_filename, audio_id=128, verbose_flag=0, dry_run_flag=0):
+def extract_audio(video_source_filename, audio_id=128, verbose_flag=0, dry_run_flag=0):
     '''This extracts the given audio_id track as raw uncompressed PCM from the given source video.
         Note that mplayer always saves this to audiodump.wav.
         At this time there is no way to set the output audio name.
@@ -474,7 +474,7 @@ def extract_audio (video_source_filename, audio_id=128, verbose_flag=0, dry_run_
         run(cmd)
         print()
 
-def extract_subtitles (video_source_filename, subtitle_id=0, verbose_flag=0, dry_run_flag=0):
+def extract_subtitles(video_source_filename, subtitle_id=0, verbose_flag=0, dry_run_flag=0):
     '''This extracts the given subtitle_id track as VOBSUB format from the given source video.
     '''
     cmd = "mencoder -quiet '%(video_source_filename)s' -o /dev/null -nosound -ovc copy -vobsubout subtitles -vobsuboutindex 0 -sid %(subtitle_id)s" % locals()
@@ -483,7 +483,7 @@ def extract_subtitles (video_source_filename, subtitle_id=0, verbose_flag=0, dry
         run(cmd)
         print()
 
-def get_length (audio_raw_filename):
+def get_length(audio_raw_filename):
     '''This attempts to get the length of the media file (length is time in seconds).
     This should not be confused with size (in bytes) of the file data.
     This is best used on a raw PCM AUDIO file because mplayer cannot get an accurate
@@ -504,11 +504,11 @@ def get_length (audio_raw_filename):
         return -1
     return float(idl[0])
 
-def get_filesize (filename):
+def get_filesize(filename):
     '''This returns the number of bytes a file takes on storage.'''
     return os.stat(filename)[stat.ST_SIZE]
 
-def calc_video_bitrate (video_target_size, audio_bitrate, video_length, extra_space=0, dry_run_flag=0):
+def calc_video_bitrate(video_target_size, audio_bitrate, video_length, extra_space=0, dry_run_flag=0):
     '''This gives an estimate of the video bitrate necessary to
     fit the final target size.  This will take into account room to
     fit the audio and extra space if given (for container overhead or whatnot).
@@ -527,9 +527,9 @@ def calc_video_bitrate (video_target_size, audio_bitrate, video_length, extra_sp
     #audio_size = os.stat(audio_compressed_filename)[stat.ST_SIZE]
     audio_size = (audio_bitrate * video_length * 1000) / 8.0
     video_target_size = video_target_size - audio_size - extra_space
-    return (int)(calc_video_kbitrate (video_target_size, video_length))
+    return (int)(calc_video_kbitrate(video_target_size, video_length))
 
-def calc_video_kbitrate (target_size, length_secs):
+def calc_video_kbitrate(target_size, length_secs):
     '''Given a target byte size free for video data, this returns the bitrate in kBit/S.
     For mencoder vbitrate 1 kBit = 1000 Bits -- not 1024 bits.
         target_size = bitrate * 1000 * length_secs / 8
@@ -538,7 +538,7 @@ def calc_video_kbitrate (target_size, length_secs):
     '''
     return int(target_size / (125.0 * length_secs))
 
-def crop_detect (video_source_filename, video_length, dry_run_flag=0):
+def crop_detect(video_source_filename, video_length, dry_run_flag=0):
     '''This attempts to figure out the best crop for the given video file.
     Basically it runs crop detect for 10 seconds on five different places in the video.
     It picks the crop area that was most often detected.
@@ -566,7 +566,7 @@ def crop_detect (video_source_filename, video_length, dry_run_flag=0):
     return items_count[0][1]
 
 
-def build_compression_command (video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None, seek_skip=None, seek_length=None, video_chapter=None):
+def build_compression_command(video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None, seek_skip=None, seek_length=None, video_chapter=None):
 #Notes:For DVD, VCD, and SVCD use acodec=mp2 and vcodec=mpeg2video:
 #mencoder movie.avi -o movie.VOB -ovc lavc -oac lavc -lavcopts acodec=mp2:abitrate=224:vcodec=mpeg2video:vbitrate=2000
 
@@ -636,26 +636,26 @@ def build_compression_command (video_source_filename, video_final_filename, vide
     cmd = "mencoder -quiet -info comment='Arkivist' '%(video_source_filename)s' %(seek_filter)s %(chapter)s -aid %(audio_id)s -o '%(video_final_filename)s' -ffourcc %(video_fourcc_override)s -ovc lavc -oac mp3lame %(lavcopts)s %(video_filter)s %(audio_filter)s" % locals()
     return cmd
 
-def compression_estimate (video_length, video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None):
+def compression_estimate(video_length, video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None):
     '''This attempts to figure out the best compression ratio for a given set of compression options.
     '''
     # TODO Need to account for AVI overhead.
     skip = int(video_length/9) # offset to skip (-ss option in mencoder)
     sample_length = 10
-    cmd1 = build_compression_command (video_source_filename, "compression_test_1.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip, sample_length)
-    cmd2 = build_compression_command (video_source_filename, "compression_test_2.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*2, sample_length)
-    cmd3 = build_compression_command (video_source_filename, "compression_test_3.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*4, sample_length)
-    cmd4 = build_compression_command (video_source_filename, "compression_test_4.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*6, sample_length)
-    cmd5 = build_compression_command (video_source_filename, "compression_test_5.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*8, sample_length)
+    cmd1 = build_compression_command(video_source_filename, "compression_test_1.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip, sample_length)
+    cmd2 = build_compression_command(video_source_filename, "compression_test_2.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*2, sample_length)
+    cmd3 = build_compression_command(video_source_filename, "compression_test_3.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*4, sample_length)
+    cmd4 = build_compression_command(video_source_filename, "compression_test_4.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*6, sample_length)
+    cmd5 = build_compression_command(video_source_filename, "compression_test_5.avi", video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, skip*8, sample_length)
     run(cmd1)
     run(cmd2)
     run(cmd3)
     run(cmd4)
     run(cmd5)
-    size = get_filesize ("compression_test_1.avi")+get_filesize ("compression_test_2.avi")+get_filesize ("compression_test_3.avi")+get_filesize ("compression_test_4.avi")+get_filesize ("compression_test_5.avi")
+    size = get_filesize("compression_test_1.avi")+get_filesize("compression_test_2.avi")+get_filesize("compression_test_3.avi")+get_filesize("compression_test_4.avi")+get_filesize("compression_test_5.avi")
     return (size / 5.0)
 
-def compress_video (video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None, seek_skip=None, seek_length=None, video_chapter=None, verbose_flag=0, dry_run_flag=0):
+def compress_video(video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None, seek_skip=None, seek_length=None, video_chapter=None, verbose_flag=0, dry_run_flag=0):
     '''This compresses the video and audio of the given source video filename to the transcoded filename.
         This does a two-pass compression (I'm assuming mpeg4, I should probably make this smarter for other formats).
     '''
@@ -664,7 +664,7 @@ def compress_video (video_source_filename, video_final_filename, video_target_si
     #
     #cmd = "mencoder -quiet '%(video_source_filename)s' -ss 65 -endpos 20 -aid %(audio_id)s -o '%(video_final_filename)s' -ffourcc %(video_fourcc_override)s -ovc lavc -oac lavc %(lavcopts)s %(video_filter)s %(audio_filter)s" % locals()
 
-    cmd = build_compression_command (video_source_filename, video_final_filename, video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, seek_skip, seek_length, video_chapter)
+    cmd = build_compression_command(video_source_filename, video_final_filename, video_target_size, audio_id, video_bitrate, video_codec, audio_codec, video_fourcc_override, video_gray_flag, video_crop_area, video_aspect_ratio, video_scale, video_encode_passes, video_deinterlace_flag, audio_volume_boost, audio_sample_rate, audio_bitrate, seek_skip, seek_length, video_chapter)
     if verbose_flag: print(cmd)
     if not dry_run_flag:
         run(cmd)
@@ -675,7 +675,7 @@ def compress_video (video_source_filename, video_final_filename, video_target_si
         return
 
     if verbose_flag:
-        video_actual_size = get_filesize (video_final_filename)
+        video_actual_size = get_filesize(video_final_filename)
         if video_actual_size > video_target_size:
             print("=======================================================")
             print("WARNING!")
@@ -687,14 +687,14 @@ def compress_video (video_source_filename, video_final_filename, video_target_si
     #
     # do the second pass video compression
     #
-    cmd = cmd.replace ('vpass=1', 'vpass=2')
+    cmd = cmd.replace('vpass=1', 'vpass=2')
     if verbose_flag: print(cmd)
     if not dry_run_flag:
         run(cmd)
         print()
     return
 
-def compress_audio (audio_raw_filename, audio_compressed_filename, audio_lowpass_filter=None, audio_sample_rate=None, audio_bitrate=None, verbose_flag=0, dry_run_flag=0):
+def compress_audio(audio_raw_filename, audio_compressed_filename, audio_lowpass_filter=None, audio_sample_rate=None, audio_bitrate=None, verbose_flag=0, dry_run_flag=0):
     '''This is depricated.
     This compresses the raw audio file to the compressed audio filename.
     '''
@@ -714,15 +714,15 @@ def compress_audio (audio_raw_filename, audio_compressed_filename, audio_lowpass
         if exitstatus != 0:
             raise Exception('ERROR: lame failed to compress raw audio file.')
 
-def mux (video_final_filename, video_transcoded_filename, audio_compressed_filename, video_container_format, verbose_flag=0, dry_run_flag=0):
+def mux(video_final_filename, video_transcoded_filename, audio_compressed_filename, video_container_format, verbose_flag=0, dry_run_flag=0):
     '''This is depricated. I used to use a three-pass encoding where I would mix the audio track separately, but
     this never worked very well (loss of audio sync).'''
     if video_container_format.lower() == 'mkv': # Matroska
-        mux_mkv (video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag, dry_run_flag)
+        mux_mkv(video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag, dry_run_flag)
     if video_container_format.lower() == 'avi':
-        mux_avi (video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag, dry_run_flag)
+        mux_avi(video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag, dry_run_flag)
 
-def mux_mkv (video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag=0, dry_run_flag=0):
+def mux_mkv(video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag=0, dry_run_flag=0):
     '''This is depricated.'''
     cmd = 'mkvmerge -o %s --noaudio %s %s' % (video_final_filename, video_transcoded_filename, audio_compressed_filename)
     if verbose_flag: print(cmd)
@@ -730,7 +730,7 @@ def mux_mkv (video_final_filename, video_transcoded_filename, audio_compressed_f
         run(cmd)
         print()
 
-def mux_avi (video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag=0, dry_run_flag=0):
+def mux_avi(video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag=0, dry_run_flag=0):
     '''This is depricated.'''
     pass
 #    cmd = "mencoder -quiet -oac copy -ovc copy -o '%s' -audiofile %s '%s'" % (video_final_filename, audio_compressed_filename, video_transcoded_filename)
@@ -739,9 +739,9 @@ def mux_avi (video_final_filename, video_transcoded_filename, audio_compressed_f
 #        run(cmd)
 #        print
 
-def delete_tmp_files (audio_raw_filename, verbose_flag=0, dry_run_flag=0):
+def delete_tmp_files(audio_raw_filename, verbose_flag=0, dry_run_flag=0):
     global GLOBAL_LOGFILE_NAME
-    file_list = ' '.join([GLOBAL_LOGFILE_NAME, 'divx2pass.log', audio_raw_filename ])
+    file_list = ' '.join([GLOBAL_LOGFILE_NAME, 'divx2pass.log', audio_raw_filename])
     cmd = 'rm -f ' + file_list
     if verbose_flag: print(cmd)
     if not dry_run_flag:
@@ -751,7 +751,7 @@ def delete_tmp_files (audio_raw_filename, verbose_flag=0, dry_run_flag=0):
 ##############################################################################
 # This is the interactive Q&A that is used if a conf file was not given.
 ##############################################################################
-def interactive_convert ():
+def interactive_convert():
 
     global prompts, prompts_key_order
 
@@ -781,9 +781,9 @@ def interactive_convert ():
     for k in prompts_key_order:
         if k == 'video_aspect_ratio':
             guess_aspect = get_aspect_ratio(options['video_source_filename'])
-            options[k] = input_option (prompts[k][1], guess_aspect, prompts[k][2], prompts[k][3], max_prompt_level)
+            options[k] = input_option(prompts[k][1], guess_aspect, prompts[k][2], prompts[k][3], max_prompt_level)
         elif k == 'audio_id':
-            aid_list = get_aid_list (options['video_source_filename'])
+            aid_list = get_aid_list(options['video_source_filename'])
             default_id = '128'
             if max_prompt_level>=prompts[k][3]:
                 if len(aid_list) > 1:
@@ -797,9 +797,9 @@ def interactive_convert ():
                     print("If reading directly from a DVD then the DVD device might be busy.")
                     print("Using a default setting of stream id 128 (main audio on most DVDs).")
                     default_id = '128'
-            options[k] = input_option (prompts[k][1], default_id, prompts[k][2], prompts[k][3], max_prompt_level)
+            options[k] = input_option(prompts[k][1], default_id, prompts[k][2], prompts[k][3], max_prompt_level)
         elif k == 'subtitle_id':
-            sid_list = get_sid_list (options['video_source_filename'])
+            sid_list = get_sid_list(options['video_source_filename'])
             default_id = 'None'
             if max_prompt_level>=prompts[k][3]:
                 if len(sid_list) > 0:
@@ -813,15 +813,15 @@ def interactive_convert ():
                     print("Unable to get the list of subtitle streams from this video. It may have none.")
                     print("Setting default to None.")
                     default_id = 'None'
-            options[k] = input_option (prompts[k][1], default_id, prompts[k][2], prompts[k][3], max_prompt_level)
+            options[k] = input_option(prompts[k][1], default_id, prompts[k][2], prompts[k][3], max_prompt_level)
         elif k == 'audio_lowpass_filter':
             lowpass_default =  "%.1f" % (math.floor(float(options['audio_sample_rate']) / 2.0))
-            options[k] = input_option (prompts[k][1], lowpass_default, prompts[k][2], prompts[k][3], max_prompt_level)
+            options[k] = input_option(prompts[k][1], lowpass_default, prompts[k][2], prompts[k][3], max_prompt_level)
         elif k == 'video_bitrate':
             if options['video_length'].lower() == 'none':
-                options[k] = input_option (prompts[k][1], '1000', prompts[k][2], prompts[k][3], max_prompt_level)
+                options[k] = input_option(prompts[k][1], '1000', prompts[k][2], prompts[k][3], max_prompt_level)
             else:
-                options[k] = input_option (prompts[k][1], prompts[k][0], prompts[k][2], prompts[k][3], max_prompt_level)
+                options[k] = input_option(prompts[k][1], prompts[k][0], prompts[k][2], prompts[k][3], max_prompt_level)
         else:
             # don't bother asking for video_target_size or video_bitrate_overhead if video_bitrate was set
             if (k=='video_target_size' or k=='video_bitrate_overhead') and options['video_bitrate']!='calc':
@@ -830,7 +830,7 @@ def interactive_convert ():
             if k == 'video_crop_area' and options['video_length'].lower() == 'none':
                 options['video_crop_area'] = 'none'
                 continue
-            options[k] = input_option (prompts[k][1], prompts[k][0], prompts[k][2], prompts[k][3], max_prompt_level)
+            options[k] = input_option(prompts[k][1], prompts[k][0], prompts[k][2], prompts[k][3], max_prompt_level)
 
     #options['video_final_filename'] = options['video_final_filename'] + "." + options['video_container_format']
 
@@ -849,7 +849,7 @@ def interactive_convert ():
         os._exit(1)
     return options
 
-def clean_options (d):
+def clean_options(d):
     '''This validates and cleans up the options dictionary.
     After reading options interactively or from a conf file
     we need to make sure that the values make sense and are
@@ -937,7 +937,7 @@ def clean_options (d):
     assert (not (d['video_length']=='none' and d['video_bitrate']=='calc'))
     return d
 
-def main ():
+def main():
     try:
         optlist, args = getopt.getopt(sys.argv[1:], 'h?', ['help','h','?'])
     except Exception as e:
@@ -968,11 +968,11 @@ def main ():
         # cute one-line string-to-dictionary parser (two-lines if you count this comment):
         options = dict(re.findall('([^: \t\n]*)\s*:\s*(".*"|[^ \t\n]*)', file(args[0]).read()))
         options = clean_options(options)
-        convert (options)
+        convert(options)
     else:
-        options = interactive_convert ()
+        options = interactive_convert()
         options = clean_options(options)
-        convert (options)
+        convert(options)
     print("# Done!")
 
 if __name__ == "__main__":
@@ -996,4 +996,3 @@ if __name__ == "__main__":
         print(str(tb_dump), file=GLOBAL_LOGFILE)
         print("==========================================================================", file=GLOBAL_LOGFILE)
         exit_with_usage(3)
-

--- a/examples/script.py
+++ b/examples/script.py
@@ -83,7 +83,7 @@ def main():
         command = "sh"
 
     # Begin log with date/time in the form CCCCyymm.hhmmss
-    fout.write ('# %4d%02d%02d.%02d%02d%02d \n' % time.localtime()[:-3])
+    fout.write('# %4d%02d%02d.%02d%02d%02d \n' % time.localtime()[:-3])
 
     ######################################################################
     # Start the interactive session
@@ -99,15 +99,15 @@ def main():
     fout.close()
     return 0
 
-def sigwinch_passthrough (sig, data):
+def sigwinch_passthrough(sig, data):
 
     # Check for buggy platforms (see pexpect.setwinsize()).
     if 'TIOCGWINSZ' in dir(termios):
         TIOCGWINSZ = termios.TIOCGWINSZ
     else:
         TIOCGWINSZ = 1074295912 # assume
-    s = struct.pack ("HHHH", 0, 0, 0, 0)
-    a = struct.unpack ('HHHH', fcntl.ioctl(sys.stdout.fileno(), TIOCGWINSZ , s))
+    s = struct.pack("HHHH", 0, 0, 0, 0)
+    a = struct.unpack('HHHH', fcntl.ioctl(sys.stdout.fileno(), TIOCGWINSZ, s))
     global global_pexpect_instance
     global_pexpect_instance.setwinsize(a[0],a[1])
 
@@ -121,4 +121,3 @@ if __name__ == "__main__":
         print(str(e))
         traceback.print_exc()
         os._exit(1)
-

--- a/examples/ssh_session.py
+++ b/examples/ssh_session.py
@@ -117,4 +117,3 @@ class ssh_session:
             return None # File doesn't exist
         else:
             return seen.split()[0] # Return permission field of listing.
-

--- a/examples/ssh_tunnel.py
+++ b/examples/ssh_tunnel.py
@@ -53,53 +53,52 @@ host = raw_input('Hostname: ')
 user = raw_input('Username: ')
 X = getpass.getpass('Password: ')
 
-def get_process_info ():
+def get_process_info():
 
     # This seems to work on both Linux and BSD, but should otherwise be considered highly UNportable.
 
-    ps = pexpect.run ('ps ax -O ppid')
+    ps = pexpect.run('ps ax -O ppid')
     pass
 
-def start_tunnel ():
+def start_tunnel():
 
     try:
-        ssh_tunnel = pexpect.spawn (tunnel_command % globals())
-        ssh_tunnel.expect ('password:')
-        time.sleep (0.1)
-        ssh_tunnel.sendline (X)
-        time.sleep (60) # Cygwin is slow to update process status.
-        ssh_tunnel.expect (pexpect.EOF)
+        ssh_tunnel = pexpect.spawn(tunnel_command % globals())
+        ssh_tunnel.expect('password:')
+        time.sleep(0.1)
+        ssh_tunnel.sendline(X)
+        time.sleep(60) # Cygwin is slow to update process status.
+        ssh_tunnel.expect(pexpect.EOF)
 
     except Exception as e:
         print(str(e))
 
-def main ():
+def main():
 
     while True:
-        ps = pexpect.spawn ('ps')
-        time.sleep (1)
-        index = ps.expect (['/usr/bin/ssh', pexpect.EOF, pexpect.TIMEOUT])
+        ps = pexpect.spawn('ps')
+        time.sleep(1)
+        index = ps.expect(['/usr/bin/ssh', pexpect.EOF, pexpect.TIMEOUT])
         if index == 2:
             print('TIMEOUT in ps command...')
             print(str(ps))
-            time.sleep (13)
+            time.sleep(13)
         if index == 1:
             print(time.asctime(), end=' ')
             print('restarting tunnel')
-            start_tunnel ()
-            time.sleep (11)
+            start_tunnel()
+            time.sleep(11)
             print('tunnel OK')
         else:
             # print 'tunnel OK'
-            time.sleep (7)
+            time.sleep(7)
 
 if __name__ == '__main__':
 
-    main ()
+    main()
 
 # This was for older SSH versions that didn't have -f option
 #tunnel_command = 'ssh -C -n -L 25:%(host)s:25 -L 110:%(host)s:110 %(user)s@%(host)s -f nothing.sh'
 #nothing_script = '''#!/bin/sh
 #while true; do sleep 53; done
 #'''
-

--- a/examples/sshls.py
+++ b/examples/sshls.py
@@ -36,7 +36,7 @@ except NameError:
     raw_input = input
 
 
-def ssh_command (user, host, password, command):
+def ssh_command(user, host, password, command):
 
     '''This runs a command on the remote host. This could also be done with the
     pxssh class, but this demonstrates what that class does at a simpler level.
@@ -53,8 +53,8 @@ def ssh_command (user, host, password, command):
         print(child.before, child.after)
         return None
     if i == 1: # SSH does not have the public key. Just accept it.
-        child.sendline ('yes')
-        child.expect ('password: ')
+        child.sendline('yes')
+        child.expect('password: ')
         i = child.expect([pexpect.TIMEOUT, 'password: '])
         if i == 0: # Timeout
             print('ERROR!')
@@ -64,12 +64,12 @@ def ssh_command (user, host, password, command):
     child.sendline(password)
     return child
 
-def main ():
+def main():
 
     host = raw_input('Hostname: ')
     user = raw_input('User: ')
     password = getpass.getpass('Password: ')
-    child = ssh_command (user, host, password, '/bin/ls -l')
+    child = ssh_command(user, host, password, '/bin/ls -l')
     child.expect(pexpect.EOF)
     print(child.before)
 
@@ -81,4 +81,3 @@ if __name__ == '__main__':
         print(str(e))
         traceback.print_exc()
         os._exit(1)
-

--- a/examples/topip.py
+++ b/examples/topip.py
@@ -119,13 +119,13 @@ def stats(r):
     return dict(list(zip(['med', 'avg', 'stddev', 'min', 'max'],
         (s[len(s)//2], avg, (sdsq/len(r))**.5, min(r), max(r)))))
 
-def send_alert (message, subject, addr_from, addr_to, smtp_server='localhost'):
+def send_alert(message, subject, addr_from, addr_to, smtp_server='localhost'):
 
     '''This sends an email alert.
     '''
 
-    message = ( 'From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n'
-            % (addr_from, addr_to, subject) + message )
+    message = ('From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n'
+            % (addr_from, addr_to, subject) + message)
     server = smtplib.SMTP(smtp_server)
     server.sendmail(addr_from, addr_to, message)
     server.quit()
@@ -238,8 +238,8 @@ def main():
         pass
 
     # remove a few common, uninteresting addresses from the dictionary.
-    ip_list = dict([ (key,value) for key,value in ip_list.items() if '192.168.' not in key])
-    ip_list = dict([ (key,value) for key,value in ip_list.items() if '127.0.0.1' not in key])
+    ip_list = dict([(key,value) for key,value in ip_list.items() if '192.168.' not in key])
+    ip_list = dict([(key,value) for key,value in ip_list.items() if '127.0.0.1' not in key])
 
     ip_list = list(ip_list.items())
     if len(ip_list) < 1:
@@ -262,9 +262,9 @@ def main():
         print('connections_stddev.value', s['stddev'])
         return 0
     if verbose:
-        pprint (s)
+        pprint(s)
         print()
-        pprint (ip_list[0:average_n])
+        pprint(ip_list[0:average_n])
 
     # load the stats from the last run.
     try:
@@ -272,8 +272,8 @@ def main():
     except:
         last_stats = {'maxip':None}
 
-    if ( s['maxip'][1] > (s['stddev'] * stddev_trigger)
-            and s['maxip']==last_stats['maxip'] ):
+    if (s['maxip'][1] > (s['stddev'] * stddev_trigger)
+            and s['maxip']==last_stats['maxip']):
         if verbose: print('The maxip has been above trigger for two consecutive samples.')
         if alert_flag:
             if verbose: print('SENDING ALERT EMAIL')
@@ -284,14 +284,14 @@ def main():
             fout = file(TOPIP_LOG_FILE,'a')
             #dts = time.strftime('%Y:%m:%d:%H:%M:%S', time.localtime())
             dts = time.asctime()
-            fout.write ('%s - %d connections from %s\n'
+            fout.write('%s - %d connections from %s\n'
                     % (dts,s['maxip'][1],str(s['maxip'][0])))
             fout.close()
 
     # save state to TOPIP_LAST_RUN_STATS
     try:
         pickle.dump(s, file(TOPIP_LAST_RUN_STATS,'w'))
-        os.chmod (TOPIP_LAST_RUN_STATS, 0o664)
+        os.chmod(TOPIP_LAST_RUN_STATS, 0o664)
     except:
         pass
     # p.logout()
@@ -306,4 +306,3 @@ if __name__ == '__main__':
         print(str(e))
         traceback.print_exc()
         os._exit(1)
-

--- a/examples/uptime.py
+++ b/examples/uptime.py
@@ -78,4 +78,3 @@ if 'min' in duration:
 # Print the parsed fields in CSV format.
 print('days, hours, minutes, users, cpu avg 1 min, cpu avg 5 min, cpu avg 15 min')
 print('%s, %s, %s, %s, %s, %s, %s' % (days, hours, mins, users, av1, av5, av15))
-


### PR DESCRIPTION
I noticed while porting this stuff to Python 3 that there was inconsistent formatting of parentheses (`foo (bar)`, `foo(bar)`, and `foo ( bar )`).
