### PR TITLE
Don't catch unhandled exceptions in examples.

### DIFF
--- a/examples/astat.py
+++ b/examples/astat.py
@@ -35,7 +35,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os, sys, time, re, getopt, getpass
-import traceback
 import pexpect, pxssh
 
 
@@ -94,10 +93,4 @@ def main():
     print(requests_per_second)
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        print(str(e))
-        traceback.print_exc()
-        os._exit(1)
-
+    main()

--- a/examples/hive.py
+++ b/examples/hive.py
@@ -88,7 +88,6 @@ import sys
 import os
 import re
 import optparse
-import traceback
 import types
 import time
 import getpass
@@ -453,27 +452,16 @@ def parse_host_connect_string (hcs):
     return d
 
 if __name__ == '__main__':
-    try:
-        start_time = time.time()
-        parser = optparse.OptionParser(formatter=optparse.TitledHelpFormatter(), usage=globals()['__doc__'], version='$Id: hive.py 533 2012-10-20 02:19:33Z noah $',conflict_handler="resolve")
-        parser.add_option ('-v', '--verbose', action='store_true', default=False, help='verbose output')
-        parser.add_option ('--samepass', action='store_true', default=False, help='Use same password for each login.')
-        parser.add_option ('--sameuser', action='store_true', default=False, help='Use same username for each login.')
-        (options, args) = parser.parse_args()
-        if len(args) < 1:
-            parser.error ('missing argument')
-        if options.verbose: print(time.asctime())
-        main()
-        if options.verbose: print(time.asctime())
-        if options.verbose: print('TOTAL TIME IN MINUTES:', end=' ')
-        if options.verbose: print((time.time() - start_time) / 60.0)
-        sys.exit(0)
-    except KeyboardInterrupt as e: # Ctrl-C
-        raise e
-    except SystemExit as e: # sys.exit()
-        raise e
-    except Exception as e:
-        print('ERROR, UNEXPECTED EXCEPTION')
-        print(str(e))
-        traceback.print_exc()
-        os._exit(1)
+    start_time = time.time()
+    parser = optparse.OptionParser(formatter=optparse.TitledHelpFormatter(), usage=globals()['__doc__'], version='$Id: hive.py 533 2012-10-20 02:19:33Z noah $',conflict_handler="resolve")
+    parser.add_option ('-v', '--verbose', action='store_true', default=False, help='verbose output')
+    parser.add_option ('--samepass', action='store_true', default=False, help='Use same password for each login.')
+    parser.add_option ('--sameuser', action='store_true', default=False, help='Use same username for each login.')
+    (options, args) = parser.parse_args()
+    if len(args) < 1:
+        parser.error ('missing argument')
+    if options.verbose: print(time.asctime())
+    main()
+    if options.verbose: print(time.asctime())
+    if options.verbose: print('TOTAL TIME IN MINUTES:', end=' ')
+    if options.verbose: print((time.time() - start_time) / 60.0)

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -46,7 +46,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os, sys, re, getopt, getpass
-import traceback
 import pexpect
 
 
@@ -227,11 +226,4 @@ def main():
         child.expect(EOF)
 
 if __name__ == "__main__":
-
-    try:
-        main()
-    except Exception as e:
-        print(str(e))
-        traceback.print_exc()
-        os._exit(1)
-
+    main()

--- a/examples/passmass.py
+++ b/examples/passmass.py
@@ -113,7 +113,4 @@ def main():
         child.sendline('exit')
 
 if __name__ == '__main__':
-    try:
-        main()
-    except pexpect.ExceptionPexpect as e:
-        print(str(e))
+    main()

--- a/examples/script.py
+++ b/examples/script.py
@@ -41,7 +41,6 @@ from __future__ import absolute_import
 
 import os, sys, time, getopt
 import signal, fcntl, termios, struct
-import traceback
 import pexpect
 
 global_pexpect_instance = None # Used by signal handler
@@ -112,13 +111,4 @@ def sigwinch_passthrough (sig, data):
     global_pexpect_instance.setwinsize(a[0],a[1])
 
 if __name__ == "__main__":
-    try:
-        main()
-    except SystemExit as e:
-        raise e
-    except Exception as e:
-        print("ERROR")
-        print(str(e))
-        traceback.print_exc()
-        os._exit(1)
-
+    main()

--- a/examples/topip.py
+++ b/examples/topip.py
@@ -78,7 +78,6 @@ import getopt
 import pickle
 import getpass
 import smtplib
-import traceback
 from pprint import pprint
 
 
@@ -297,13 +296,4 @@ def main():
     # p.logout()
 
 if __name__ == '__main__':
-    try:
-        main()
-        sys.exit(0)
-    except SystemExit as e:
-        raise e
-    except Exception as e:
-        print(str(e))
-        traceback.print_exc()
-        os._exit(1)
-
+    main()

--- a/pexpect/FSM.py
+++ b/pexpect/FSM.py
@@ -265,8 +265,6 @@ class FSM:
 ##############################################################################
 
 import sys
-import os
-import traceback
 import string
 
 PY3 = (sys.version_info[0] >= 3)


### PR DESCRIPTION
Let Python handle printing a traceback and exiting in these cases.
