### PR TITLE
Allow importing when sys.stdout is reassigned on Python 3

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -283,7 +283,14 @@ class spawn(object):
         def _chr(c):
             return bytes([c])
         linesep = os.linesep.encode('ascii')
-        write_to_stdout = sys.stdout.buffer.write
+
+        @staticmethod
+        def write_to_stdout(b):
+            try:
+                return sys.stdout.buffer.write(b)
+            except AttributeError:
+                # If stdout has been replaced, it may not have .buffer
+                return sys.stdout.write(b.decode('ascii', 'replace'))
     else:
         allowed_string_types = (basestring,)  # analysis:ignore
         _chr = staticmethod(chr)


### PR DESCRIPTION
Closes gh-30

`sys.stdout.buffer` is not guaranteed to exist - e.g. if `sys.stdout` has been reassigned to an `io.StringIO` instance, it won't. This is only used by the `.interact()` method, so it should normally be in interactive cases with 'real' system stdout, but we need at least some fallback for when it isn't - and we certainly need to avoid relying on it at import time.

We should think about the binding order. If `sys.stdout` is reassigned between importing pexpect and calling the `.interact()` method, this case (spawn class on Python 3) will pick up the new stdout, but the other cases (spawnu on Python 3, either class on Python 2) won't. However, interact goes on to use direct access to stdout (and stdin) by fileno, so any redirection at the Python level won't be effective anyway.
