### PR TITLE
Correctly handle when select in spawn returns with an error (e.g. SIGWINCH...

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -1679,7 +1679,7 @@ class spawn(object):
                 return select.select(iwtd, owtd, ewtd, timeout)
             except select.error:
                 err = sys.exc_info()[1]
-                if err[0] == errno.EINTR:
+                if err.errno == errno.EINTR:
                     # if we loop back we have to subtract the
                     # amount of time we already waited.
                     if timeout is not None:


### PR DESCRIPTION
passes tools/testall.py
