### PR TITLE
Bug: AttributeError: 'error' object has no attribute 'errno'

### DIFF
--- a/tests/sleep_for.py
+++ b/tests/sleep_for.py
@@ -22,10 +22,19 @@ PEXPECT LICENSE
 from  __future__ import print_function
 
 import time
+import sys
 
 def main():
+    """
+        This script sleeps for the number of seconds (float) specified by the
+        command line argument.
+    """
+    if len(sys.argv) < 2:
+        print("Usage: %s seconds_to_sleep" % (sys.argv[0],))
+        sys.exit(1)
+    timeout = float(sys.argv[1])
     print("READY")
-    time.sleep(2)
+    time.sleep(timeout)
     print("END")
 
 if __name__ == '__main__':

--- a/tests/test_winsize.py
+++ b/tests/test_winsize.py
@@ -22,7 +22,6 @@ import pexpect
 import unittest
 import PexpectTestCase
 import time
-import signal
 
 class TestCaseWinsize(PexpectTestCase.PexpectTestCase):
 
@@ -52,20 +51,6 @@ class TestCaseWinsize(PexpectTestCase.PexpectTestCase):
         self.assertEqual(p1.getwinsize(), (24, 80))
 
         p1.close()
-
-    def test_sinch_error (self):
-        '''
-        This tests that the child process can set and get the windows size.
-        This makes use of an external script sigwinch_report.py.
-        '''
-        def noop(x, y):
-            pass
-        signal.signal(signal.SIGALRM, noop)
-    
-        p1 = pexpect.spawn('%s sigwinch_error.py' % self.PYTHONBIN)
-        p1.expect('READY', timeout=10)
-        signal.alarm(1)
-        p1.expect('END', timeout=10)
 
 #    def test_parent_resize (self):
 #        pid = os.getpid()


### PR DESCRIPTION
This fixes an issue I am encountering where 'errno' is not an attribute of the 'select.error' class. This preserves the behavior should the errno attribute exist, but allows the old behavior (changed in commit efa531aa2364f2e4edad8ac646141bedf6b5b97e on 2013-12-30) to continue to function.

I got this issue when using pexpect3.1 on python2.7.3 and passing a SIGWINCH via signal after running interact

In short: I resize my window, pexpect causes program to crash

...
  File "/home/mprintz/temp/pexpect3/local/lib/python2.7/site-packages/pexpect/**init**.py", line 1690, in __select
    if err.errno == errno.EINTR:
AttributeError: 'error' object has no attribute 'errno'
