### PR TITLE
Resolves Issue #49 -- bad fdspawned-interact()

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -1645,8 +1645,9 @@ class spawn(object):
                     data = self.__interact_read(self.child_fd)
                 except OSError as e:
                     # The subprocess may have closed before we get to reading it
-                    if e.errno != errno.EIO:
-                        raise
+                    if e.errno == errno.EIO:
+                        break # EOF on linux
+                    raise
                 if output_filter:
                     data = output_filter(data)
                 if self.logfile is not None:


### PR DESCRIPTION
tested on centos using script by @aidanhs, not that doing your own
pty.fork() is really recommended if you're going to use interact

Otherwise, tested also using traditional use of interact, though
that worked fine previously -- it still works fine, now.  With
this, the test script provided by aidnhs now exits fine.

I would be interested in a test case and a more precise use-case.
In my opinion, needs more study before acceptance.
