### PR TITLE
Issue #82: Handle more than two numbers in ANSI sequences

### DIFF
--- a/pexpect/ANSI.py
+++ b/pexpect/ANSI.py
@@ -271,11 +271,12 @@ class ANSI (term):
 
         # Create a state for 'q' and 'm' which allows an infinite number of ignored numbers
         self.state.add_transition_any ('SEMICOLON_X', DoLog, 'INIT')
-        self.state.add_transition_list (string.digits, 'SEMICOLON_X', None, 'NUMBER_X')
+        self.state.add_transition_list (string.digits, 'SEMICOLON_X', DoStartNumber, 'NUMBER_X')
+        self.state.add_transition_list (string.digits, 'NUMBER_X', DoBuildNumber, 'NUMBER_X')
         self.state.add_transition_any ('NUMBER_X', DoLog, 'INIT')
         self.state.add_transition ('m', 'NUMBER_X', None, 'INIT')
         self.state.add_transition ('q', 'NUMBER_X', None, 'INIT')
-        self.state.add_transition (';', 'NUMBER_2', None, 'SEMICOLON_X')
+        self.state.add_transition (';', 'NUMBER_X', None, 'SEMICOLON_X')
 
     def process (self, c):
         """Process a single byte. Called by :meth:`write`."""

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -140,6 +140,13 @@ class ansiTestCase (PexpectTestCase.PexpectTestCase):
                           'cd   \n'
                           '     ')
 
+    def test_number_x(self):
+        """Test the FSM state used to handle more than 2 numeric parameters."""
+        s = ANSI.ANSI(1, 20)
+        s.write('\x1b[0;1;32;45mtest')
+        assert str(s) == ('test                ')
+        assert(s.state.memory == [s, '0', '1', '32', '45'])
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
FSM transitions were not set up to accept more than one digit in the
third number, or to accept more than three numbers, in ANSI sequences
such as '\x1b[...m'.  They were also not set up to capture the third
and subsequent numbers.  This fix corrects these issues and adds a
unit test.
