### PR TITLE
update documentation string in pexpect/__init__.py to be compatible with...

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -365,12 +365,17 @@ class spawn(object):
         Example log input and output to a file::
 
             child = pexpect.spawn('some_command')
-            fout = file('mylog.txt','w')
+            fout = open('mylog.txt','wb')
             child.logfile = fout
 
         Example log to stdout::
 
+            # In Python 2:
             child = pexpect.spawn('some_command')
+            child.logfile = sys.stdout
+
+            # In Python 3, spawnu should be used to give str to stdout:
+            child = pexpect.spawnu('some_command')
             child.logfile = sys.stdout
 
         The logfile_read and logfile_send members can be used to separately log
@@ -380,10 +385,13 @@ class spawn(object):
 
             child = pexpect.spawn('some_command')
             child.logfile_read = sys.stdout
+        
+        Remember to use spawnu instead of spawn for the above code if you are
+        using Python 3.
 
         To separately log output sent to the child use logfile_send::
 
-            self.logfile_send = fout
+            child.logfile_send = fout
 
         If ``ignore_sighup`` is True, the child process will ignore SIGHUP
         signals. For now, the default is True, to preserve the behaviour of


### PR DESCRIPTION
Update documentation string in pexpect/**init**.py to be compatible with python 2 and 3.
With the examples in the previous doc string running in Python 3, without changing file open mode from 'w' to 'wb' or using spawnu instead of spawn for logging to stdout, the following exception will be raised:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.4/site-packages/pexpect-3.2-py3.4.egg/pexpect/__init__.py", line 1418, in expect
  File "/usr/lib/python3.4/site-packages/pexpect-3.2-py3.4.egg/pexpect/__init__.py", line 1433, in expect_list
  File "/usr/lib/python3.4/site-packages/pexpect-3.2-py3.4.egg/pexpect/__init__.py", line 1502, in expect_loop
  File "/usr/lib/python3.4/site-packages/pexpect-3.2-py3.4.egg/pexpect/__init__.py", line 926, in read_nonblocking
  File "/usr/lib/python3.4/site-packages/pexpect-3.2-py3.4.egg/pexpect/__init__.py", line 847, in _log
TypeError: must be str, not bytes
```

The updated doc string will be more user-friendly to Python 3 users.
