### PR TITLE
Allow SSH options to be passed to pxssh.login()

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -214,7 +214,7 @@ class pxssh (spawn):
     def login (self, server, username, password='', terminal_type='ansi',
                 original_prompt=r"[#$]", login_timeout=10, port=None,
                 auto_prompt_reset=True, ssh_key=None, quiet=True,
-                sync_multiplier=1, check_local_ip=True):
+                sync_multiplier=1, check_local_ip=True, ssh_options=''):
         '''This logs the user into the given server.
 
         It uses
@@ -241,7 +241,6 @@ class pxssh (spawn):
         manually set the :attr:`PROMPT` attribute.
         '''
 
-        ssh_options = ''
         if quiet:
             ssh_options = ssh_options + ' -q'
         if not check_local_ip:


### PR DESCRIPTION
It would be nice to pass custom SSH options into login(). In my use case, I want to ignore .ssh/config by passing '-F /dev/null'. I think an older version of pxssh() had this feature, but it seems to have been removed.
