### PR TITLE
enable echo deactivation in pxssh

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -86,9 +86,9 @@ class pxssh (spawn):
     '''
 
     def __init__ (self, timeout=30, maxread=2000, searchwindowsize=None,
-                    logfile=None, cwd=None, env=None):
+                    logfile=None, cwd=None, env=None, echo=True):
 
-        spawn.__init__(self, None, timeout=timeout, maxread=maxread, searchwindowsize=searchwindowsize, logfile=logfile, cwd=cwd, env=env)
+        spawn.__init__(self, None, timeout=timeout, maxread=maxread, searchwindowsize=searchwindowsize, logfile=logfile, cwd=cwd, env=env, echo=echo)
 
         self.name = '<pxssh>'
 


### PR DESCRIPTION
I've learned from #112 that you can deactivate echoing of the input via
constructer parameter. This patch enables pxssh to do the same.

In spawn there is an alternative to the constructor parameter, which is
`set_echo(False)`. Sadly that doesn't work, at least in my experiments with
localhost.

Signed-off-by: Erik Bernoth erik.bernoth@gmail.com
