### PR TITLE
Potential fix for issue #119

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -727,7 +727,9 @@ class spawn(object):
         # accordingly. Either way, the parent blocks until the child calls
         # exec.
         if len(data) != 0:
-            raise OSError(data.decode('utf-8'))
+            exception = OSError(data.decode('utf-8'))
+            exception.errno = errno.ENOEXEC
+            raise exception
 
         try:
             self.setwinsize(24, 80)

--- a/tests/test_invalid_binary.py
+++ b/tests/test_invalid_binary.py
@@ -24,6 +24,7 @@ from . import PexpectTestCase
 import os
 import stat
 import tempfile
+import errno
 
 class InvalidBinaryChars(PexpectTestCase.PexpectTestCase):
 
@@ -51,9 +52,14 @@ class InvalidBinaryChars(PexpectTestCase.PexpectTestCase):
             os.unlink(fullpath)
             os.rmdir(dirpath)
             raise AssertionError("OSError was not raised")
-        except OSError:
-            # This is what should happen
-            pass
+        except OSError as err:
+            if errno.ENOEXEC == err.errno:
+                # This is what should happen
+                pass
+            else:
+                os.unlink(fullpath)
+                os.rmdir(dirpath)
+                raise AssertionError("Wrong OSError raised")
 
         os.unlink(fullpath)
         os.rmdir(dirpath)


### PR DESCRIPTION
- Adding more robust code to handle the case where the exec call within spawn fails.  Now, spawn will raise an exception if this happens.
- Adding a test to ensure this exception is raised when an invalid binary is run
