### PR TITLE
Rectify docstring typo in compile_pattern_list()

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -1371,7 +1371,7 @@ class spawn(object):
              cpl = self.compile_pattern_list(my_pattern)
              while some_condition:
                 ...
-                i = self.expect_list(clp, timeout)
+                i = self.expect_list(cpl, timeout)
                 ...
         '''
 


### PR DESCRIPTION
This is a small docstring typo in the compile_pattern_list() method of **init**.py.
