### PR TITLE
Bugfix for solaris in replwrap.bash()

### DIFF
--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -108,6 +108,6 @@ def python(command="python"):
 def bash(command="bash"):
     """Start a bash shell and return a :class:`REPLWrapper` object."""
     bashrc = os.path.join(os.path.dirname(__file__), 'bashrc.sh')
-    child = pexpect.spawnu(command, ['--rcfile', bashrc])
+    child = pexpect.spawnu(command, ['--rcfile', bashrc], echo=False)
     return REPLWrapper(child, u'\$', u("PS1='{0}' PS2='{1}' PROMPT_COMMAND=''"),
                        extra_init_cmd="export PAGER=cat")


### PR DESCRIPTION
Forgot to set `echo=False` when calling spawnu() directly,
resulting in IOError on Solaris:

```
IOError: [Errno 22] Invalid argument: setecho() may not be called on this platform.
```
