### PR TITLE
Fix occasionally failing Solaris setwinsize()

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -676,6 +676,12 @@ class spawn(object):
             except IOError as err:
                 if err.args[0] not in (errno.EINVAL, errno.ENOTTY):
                     raise
+            except OSError as err:
+                # setwinsize (intermittently!) fails on Solaris *from the
+                # child* process, raising EXNIO. See for example in tmux,
+                # http://sourceforge.net/p/tmux/tickets/158/?limit=100
+                if err.args[0] not in (errno.EXNIO,):
+                    raise
 
             # disable echo if spawn argument echo was unset
             if not self.echo:


### PR DESCRIPTION
Although this is expected to always happen from the parent
process, it does intermittently occur on the child process:

https://teamcity-master.pexpect.org/viewLog.html?buildId=561&buildTypeId=Pexpect_SunosBuild&tab=buildLog#_focus=1292

A similar issue is found in tmux, which is referenced inline.

( There are other errors found in this build log -- but I
  suspect it is due to the forked test runner. )
