### PR TITLE
WIP: Add spawn class based on subprocess.Popen

### DIFF
--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -1,0 +1,83 @@
+"""Spawn interface using subprocess.Popen
+"""
+import os
+import threading
+import subprocess
+import sys
+
+try:
+    from queue import Queue  # Python 3
+except ImportError:
+    from Queue import Queue  # Python 2
+
+from .spawnbase import SpawnBase
+
+class PopenSpawn(SpawnBase):
+    def __init__(self, cmd, timeout=30, maxread=2000, searchwindowsize=None,
+                 logfile=None, **kwargs):
+        super(PopenSpawn, self).__init__(timeout=timeout, maxread=maxread,
+                searchwindowsize=searchwindowsize, logfile=logfile)
+                
+        kwargs.update(dict(bufsize=0, stdin=subprocess.PIPE,
+                           stderr=subprocess.STDOUT,
+                           stdout=subprocess.PIPE))
+
+        if sys.platform == 'win32':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            kwargs['startupinfo'] = startupinfo
+            kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+        self.proc = subprocess.Popen(cmd, **kwargs)
+        self._buf = ''
+
+        self._read_queue = Queue()
+        self._read_thread = threading.Thread(target=self._read_incoming)
+        self._read_thread.setDaemon(True)
+        self._read_thread.start()
+
+    def read_nonblocking(self, n):
+        orig = len(self._buf)
+        while 1:
+            try:
+                self._buf += self._read_queue.get_nowait()
+            except Queue.Empty:
+                return
+            else:
+                if len(self._buf) - orig >= n:
+                    return
+
+    def _read_incoming(self):
+        """Run in a thread to move output from a pipe to a queue."""
+        while 1:
+            buf = os.read(self.proc.stdout.fileno(), 1024)
+            self._read_queue.put(buf)
+
+    def readline(self):
+        while not '\n' in self._buf:
+            self.read_nonblocking(1024)
+            ind = self._buf.index('\n')
+            ret, self._buf = self._buf[:ind], self._buf[ind:]
+            return ret
+
+    def write(self, s):
+        '''This is similar to send() except that there is no return value.
+        '''
+        self.send(s)
+
+    def writelines(self, sequence):
+        '''This calls write() for each element in the sequence.
+        
+        The sequence can be any iterable object producing strings, typically a
+        list of strings. This does not add line separators. There is no return
+        value.
+        '''
+        for s in sequence:
+            self.send(s)
+
+    def send(self, s):
+        self._log(s, 'send')
+        return self.proc.stdin.write(s)
+
+    def sendline(self, line):
+        return self.send(line + '\n')

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -4,15 +4,24 @@ import os
 import threading
 import subprocess
 import sys
+import time
+import signal
+import shlex
 
 try:
-    from queue import Queue  # Python 3
+    from queue import Queue, Empty  # Python 3
 except ImportError:
-    from Queue import Queue  # Python 2
+    from Queue import Queue, Empty  # Python 2
 
-from .spawnbase import SpawnBase, SpawnBaseUnicode
+from .spawnbase import SpawnBase, SpawnBaseUnicode, PY3
+from .exceptions import EOF
 
 class PopenSpawn(SpawnBase):
+    if PY3:
+        crlf = '\n'.encode('ascii')
+    else:
+        crlf = '\n'
+
     def __init__(self, cmd, timeout=30, maxread=2000, searchwindowsize=None,
                  logfile=None, cwd=None,  env=None):
         super(PopenSpawn, self).__init__(timeout=timeout, maxread=maxread,
@@ -28,7 +37,11 @@ class PopenSpawn(SpawnBase):
             kwargs['startupinfo'] = startupinfo
             kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
 
+        if not isinstance(cmd, (list, tuple)):
+            cmd = shlex.split(cmd)
+
         self.proc = subprocess.Popen(cmd, **kwargs)
+        self.closed = False
         self._buf = ''
 
         self._read_queue = Queue()
@@ -36,29 +49,55 @@ class PopenSpawn(SpawnBase):
         self._read_thread.setDaemon(True)
         self._read_thread.start()
 
-    def read_nonblocking(self, n):
-        orig = len(self._buf)
-        while 1:
+    def read_nonblocking(self, size, timeout):
+        if self.closed:
+            raise ValueError('I/O operation on closed file.')
+        elif self.flag_eof:
+            self.closed = True
+            raise EOF('End Of File (EOF).')
+
+        if timeout == -1:
+            timeout = self.timeout
+        elif timeout is None:
+            timeout = 1e6
+
+        t0 = time.time()
+        buf = b''
+        while (time.time() - t0) < timeout and size and len(buf) < size:
             try:
-                self._buf += self._read_queue.get_nowait()
-            except Queue.Empty:
-                return
+                incoming = self._read_queue.get_nowait()
+            except Empty:
+                break
             else:
-                if len(self._buf) - orig >= n:
-                    return
+                if incoming is None:
+                    self.flag_eof = True
+                    raise EOF('End of File')
+
+                buf += incoming
+
+        if len(buf) > size:
+            self.buffer = buf[size:]
+            buf = buf[:size]
+
+        self._log(buf, 'read')
+        return buf
 
     def _read_incoming(self):
         """Run in a thread to move output from a pipe to a queue."""
+        fileno = self.proc.stdout.fileno()
         while 1:
-            buf = os.read(self.proc.stdout.fileno(), 1024)
-            self._read_queue.put(buf)
+            buf = ''
+            try:
+                buf = os.read(fileno, 1024)
+            except OSError as e:
+                self._log(e, 'read')
 
-    def readline(self):
-        while not '\n' in self._buf:
-            self.read_nonblocking(1024)
-            ind = self._buf.index('\n')
-            ret, self._buf = self._buf[:ind], self._buf[ind:]
-            return ret
+            if not buf:
+                self._read_queue.put(None)
+                return
+
+            self._read_queue.put(buf)
+            time.sleep(0.001)
 
     def write(self, s):
         '''This is similar to send() except that there is no return value.
@@ -79,11 +118,18 @@ class PopenSpawn(SpawnBase):
         return self.proc.stdin.write(s)
 
     def send(self, s):
+        s = self._coerce_send_string(s)
         self._log(s, 'send')
-        return self._send(s)        
 
-    def sendline(self, line):
-        return self.send(line + '\n')
+        return self._send(s)
+
+    def sendline(self, s=''):
+        '''Wraps send(), sending string ``s`` to child process, with os.linesep
+        automatically appended. Returns number of bytes written. '''
+
+        n = self.send(s)
+        n = n + self.send(self.linesep)
+        return n
 
     def wait(self):
         status = self.proc.wait()
@@ -95,6 +141,18 @@ class PopenSpawn(SpawnBase):
             self.signalstatus = -status
         self.terminated = True
         return status
+
+    def kill(self, sig):
+        if sys.platform == 'win32':
+            if sig in [signal.SIGINT, signal.CTRL_C_EVENT]:
+                sig = signal.CTRL_C_EVENT
+            elif sig in [signal.SIGBREAK, signal.CTRL_BREAK_EVENT]:
+                sig = signal.CTRL_BREAK_EVENT
+            else:
+                sig = signal.SIGTERM
+
+        os.kill(self.proc.pid, sig)
+
 
 class PopenSpawnUnicode(SpawnBaseUnicode, PopenSpawn):
     def _send(self, s):

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -116,14 +116,18 @@ class PopenSpawn(SpawnBase):
         for s in sequence:
             self.send(s)
 
-    def _send(self, s):
-        return self.proc.stdin.write(s)
-
     def send(self, s):
         s = self._coerce_send_string(s)
         self._log(s, 'send')
 
-        return self._send(s)
+        b = self._encoder.encode(s, final=False)
+        if PY3:
+            return self.proc.stdin.write(b)
+        else:
+            # On Python 2, .write() returns None, so we return the length of
+            # bytes written ourselves. This assumes they all got written.
+            self.proc.stdin.write(b)
+            return len(b)
 
     def sendline(self, s=''):
         '''Wraps send(), sending string ``s`` to child process, with os.linesep

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -99,7 +99,6 @@ class PopenSpawn(SpawnBase):
                 return
 
             self._read_queue.put(buf)
-            time.sleep(0.001)
 
     def write(self, s):
         '''This is similar to send() except that there is no return value.

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -128,8 +128,7 @@ class PopenSpawn(SpawnBase):
         automatically appended. Returns number of bytes written. '''
 
         n = self.send(s)
-        n = n + self.send(self.linesep)
-        return n
+        return n + self.send(self.linesep)
 
     def wait(self):
         status = self.proc.wait()
@@ -154,10 +153,7 @@ class PopenSpawn(SpawnBase):
         os.kill(self.proc.pid, sig)
 
     def sendeof(self):
-        if sys.platform == 'win32':
-            self.kill(signal.CTRL_BREAK_EVENT)
-        else:
-            self.kill(signal.SIGTERM)
+        self.proc.stdin.close()
 
 
 class PopenSpawnUnicode(SpawnBaseUnicode, PopenSpawn):

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -14,13 +14,13 @@ from .spawnbase import SpawnBase, SpawnBaseUnicode
 
 class PopenSpawn(SpawnBase):
     def __init__(self, cmd, timeout=30, maxread=2000, searchwindowsize=None,
-                 logfile=None, **kwargs):
+                 logfile=None, cwd=None,  env=None):
         super(PopenSpawn, self).__init__(timeout=timeout, maxread=maxread,
                 searchwindowsize=searchwindowsize, logfile=logfile)
                 
-        kwargs.update(dict(bufsize=0, stdin=subprocess.PIPE,
-                           stderr=subprocess.STDOUT,
-                           stdout=subprocess.PIPE))
+        kwargs = dict(bufsize=0, stdin=subprocess.PIPE,
+                      stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
+                      cwd=cwd, env=env)
 
         if sys.platform == 'win32':
             startupinfo = subprocess.STARTUPINFO()

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -26,7 +26,7 @@ class PopenSpawn(SpawnBase):
                  logfile=None, cwd=None,  env=None):
         super(PopenSpawn, self).__init__(timeout=timeout, maxread=maxread,
                 searchwindowsize=searchwindowsize, logfile=logfile)
-                
+
         kwargs = dict(bufsize=0, stdin=subprocess.PIPE,
                       stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
                       cwd=cwd, env=env)
@@ -106,7 +106,7 @@ class PopenSpawn(SpawnBase):
 
     def writelines(self, sequence):
         '''This calls write() for each element in the sequence.
-        
+
         The sequence can be any iterable object producing strings, typically a
         list of strings. This does not add line separators. There is no return
         value.
@@ -152,6 +152,12 @@ class PopenSpawn(SpawnBase):
                 sig = signal.SIGTERM
 
         os.kill(self.proc.pid, sig)
+
+    def sendeof(self):
+        if sys.platform == 'win32':
+            self.kill(signal.CTRL_BREAK_EVENT)
+        else:
+            self.kill(signal.SIGTERM)
 
 
 class PopenSpawnUnicode(SpawnBaseUnicode, PopenSpawn):

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from Queue import Queue, Empty  # Python 2
 
-from .spawnbase import SpawnBase, SpawnBaseUnicode, PY3
+from .spawnbase import SpawnBase, PY3
 from .exceptions import EOF
 
 class PopenSpawn(SpawnBase):
@@ -23,9 +23,11 @@ class PopenSpawn(SpawnBase):
         crlf = '\n'
 
     def __init__(self, cmd, timeout=30, maxread=2000, searchwindowsize=None,
-                 logfile=None, cwd=None,  env=None):
+                 logfile=None, cwd=None,  env=None, encoding=None,
+                 codec_errors='strict'):
         super(PopenSpawn, self).__init__(timeout=timeout, maxread=maxread,
-                searchwindowsize=searchwindowsize, logfile=logfile)
+                searchwindowsize=searchwindowsize, logfile=logfile,
+                encoding=encoding, codec_errors=codec_errors)
 
         kwargs = dict(bufsize=0, stdin=subprocess.PIPE,
                       stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
@@ -62,7 +64,7 @@ class PopenSpawn(SpawnBase):
             timeout = 1e6
 
         t0 = time.time()
-        buf = b''
+        buf = self.string_type()
         while (time.time() - t0) < timeout and size and len(buf) < size:
             try:
                 incoming = self._read_queue.get_nowait()
@@ -73,7 +75,7 @@ class PopenSpawn(SpawnBase):
                     self.flag_eof = True
                     raise EOF('End of File')
 
-                buf += incoming
+                buf += self._decoder.decode(incoming, final=False)
 
         if len(buf) > size:
             self.buffer = buf[size:]
@@ -86,7 +88,7 @@ class PopenSpawn(SpawnBase):
         """Run in a thread to move output from a pipe to a queue."""
         fileno = self.proc.stdout.fileno()
         while 1:
-            buf = ''
+            buf = b''
             try:
                 buf = os.read(fileno, 1024)
             except OSError as e:
@@ -154,8 +156,3 @@ class PopenSpawn(SpawnBase):
 
     def sendeof(self):
         self.proc.stdin.close()
-
-
-class PopenSpawnUnicode(SpawnBaseUnicode, PopenSpawn):
-    def _send(self, s):
-        super(PopenSpawnUnicode, self)._send(s.encode(self.encoding, self.errors))

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -397,7 +397,7 @@ class spawn(SpawnBase):
         then this will raise a TIMEOUT exception.
 
         The timeout refers only to the amount of time to read at least one
-        character. This is not effected by the 'size' parameter, so if you call
+        character. This is not affected by the 'size' parameter, so if you call
         read_nonblocking(size=100, timeout=30) and only one character is
         available right away then one character will be returned immediately.
         It will not wait for 30 seconds for another 99 characters to come in.

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+'''
+PEXPECT LICENSE
+
+    This license is approved by the OSI and FSF as GPL-compatible.
+        http://opensource.org/licenses/isc-license.txt
+
+    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
+    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
+    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+'''
+import unittest
+import subprocess
+
+
+import pexpect
+from pexpect.popen_spawn import PopenSpawn
+from . import PexpectTestCase
+
+
+class ExpectTestCase (PexpectTestCase.PexpectTestCase):
+
+    def test_expect(self):
+        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
+                stdout=subprocess.PIPE).communicate()[0].rstrip()
+        p = PopenSpawn('ls -l /bin')
+        the_new_way = b''
+        while 1:
+            i = p.expect([b'\n', pexpect.EOF])
+            the_new_way = the_new_way + p.before
+            if i == 1:
+                break
+            the_new_way += b'\n'
+        the_new_way = the_new_way.rstrip()
+        assert the_old_way == the_new_way, len(the_old_way) - len(the_new_way)
+
+    def test_expect_exact(self):
+        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
+                stdout=subprocess.PIPE).communicate()[0].rstrip()
+        p = PopenSpawn('ls -l /bin')
+        the_new_way = b''
+        while 1:
+            i = p.expect_exact([b'\n', pexpect.EOF])
+            the_new_way = the_new_way + p.before
+            if i == 1:
+                break
+            the_new_way += b'\n'
+        the_new_way = the_new_way.rstrip()
+
+        assert the_old_way == the_new_way, len(the_old_way) - len(the_new_way)
+        p = PopenSpawn('echo hello.?world')
+        i = p.expect_exact(b'.?')
+        self.assertEqual(p.before, b'hello')
+        self.assertEqual(p.after, b'.?')
+
+    def test_expect_eof(self):
+        the_old_way = subprocess.Popen(args=['/bin/ls', '-l', '/bin'],
+                stdout=subprocess.PIPE).communicate()[0].rstrip()
+        p = PopenSpawn('/bin/ls -l /bin')
+        # This basically tells it to read everything. Same as pexpect.run()
+        # function.
+        p.expect(pexpect.EOF)
+        the_new_way = p.before.rstrip()
+        assert the_old_way == the_new_way, len(the_old_way) - len(the_new_way)
+
+    def test_expect_timeout(self):
+        p = PopenSpawn('cat', timeout=5)
+        p.expect(pexpect.TIMEOUT)  # This tells it to wait for timeout.
+        self.assertEqual(p.after, pexpect.TIMEOUT)
+
+    def test_unexpected_eof(self):
+        p = PopenSpawn('ls -l /bin')
+        try:
+            p.expect('_Z_XY_XZ')  # Probably never see this in ls output.
+        except pexpect.EOF:
+            pass
+        else:
+            self.fail('Expected an EOF exception.')
+
+    def test_bad_arg(self):
+        p = PopenSpawn('cat')
+        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+            p.expect(1)
+        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+            p.expect([1, b'2'])
+        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+            p.expect_exact(1)
+        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+            p.expect_exact([1, b'2'])
+
+    def test_timeout_none(self):
+        p = PopenSpawn('echo abcdef', timeout=None)
+        p.expect('abc')
+        p.expect_exact('def')
+        p.expect(pexpect.EOF)
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(ExpectTestCase, 'test')

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -52,9 +52,9 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         p.expect_exact(pexpect.EOF)
 
     def test_expect(self):
-        the_old_way = subprocess.Popen(args=['ls', '-l', '~'],
+        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
                                        stdout=subprocess.PIPE).communicate()[0].rstrip()
-        p = PopenSpawn('ls -l ~')
+        p = PopenSpawn('ls -l /bin')
         the_new_way = b''
         while 1:
             i = p.expect([b'\n', pexpect.EOF])
@@ -66,9 +66,9 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         assert the_old_way == the_new_way, len(the_old_way) - len(the_new_way)
 
     def test_expect_exact(self):
-        the_old_way = subprocess.Popen(args=['ls', '-l', '~'],
+        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
                                        stdout=subprocess.PIPE).communicate()[0].rstrip()
-        p = PopenSpawn('ls -l ~')
+        p = PopenSpawn('ls -l /bin')
         the_new_way = b''
         while 1:
             i = p.expect_exact([b'\n', pexpect.EOF])
@@ -85,9 +85,9 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(p.after, b'.?')
 
     def test_expect_eof(self):
-        the_old_way = subprocess.Popen(args=['ls', '-l', '~'],
+        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
                                        stdout=subprocess.PIPE).communicate()[0].rstrip()
-        p = PopenSpawn('ls -l ~')
+        p = PopenSpawn('ls -l /bin')
         # This basically tells it to read everything. Same as pexpect.run()
         # function.
         p.expect(pexpect.EOF)
@@ -100,7 +100,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(p.after, pexpect.TIMEOUT)
 
     def test_unexpected_eof(self):
-        p = PopenSpawn('ls -l ~')
+        p = PopenSpawn('ls -l /bin')
         try:
             p.expect('_Z_XY_XZ')  # Probably never see this in ls output.
         except pexpect.EOF:

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -29,9 +29,31 @@ from . import PexpectTestCase
 
 class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
+    def test_expect_basic(self):
+        p = PopenSpawn('cat', timeout=5)
+        p.sendline(b'Hello')
+        p.sendline(b'there')
+        p.sendline(b'Mr. Python')
+        p.expect(b'Hello')
+        p.expect(b'there')
+        p.expect(b'Mr. Python')
+        p.sendeof()
+        p.expect(pexpect.EOF)
+
+    def test_expect_exact_basic(self):
+        p = PopenSpawn('cat', timeout=5)
+        p.sendline(b'Hello')
+        p.sendline(b'there')
+        p.sendline(b'Mr. Python')
+        p.expect_exact(b'Hello')
+        p.expect_exact(b'there')
+        p.expect_exact(b'Mr. Python')
+        p.sendeof()
+        p.expect_exact(pexpect.EOF)
+
     def test_expect(self):
         the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
-                stdout=subprocess.PIPE).communicate()[0].rstrip()
+                                       stdout=subprocess.PIPE).communicate()[0].rstrip()
         p = PopenSpawn('ls -l /bin')
         the_new_way = b''
         while 1:
@@ -45,7 +67,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_expect_exact(self):
         the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
-                stdout=subprocess.PIPE).communicate()[0].rstrip()
+                                       stdout=subprocess.PIPE).communicate()[0].rstrip()
         p = PopenSpawn('ls -l /bin')
         the_new_way = b''
         while 1:
@@ -64,7 +86,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_expect_eof(self):
         the_old_way = subprocess.Popen(args=['/bin/ls', '-l', '/bin'],
-                stdout=subprocess.PIPE).communicate()[0].rstrip()
+                                       stdout=subprocess.PIPE).communicate()[0].rstrip()
         p = PopenSpawn('/bin/ls -l /bin')
         # This basically tells it to read everything. Same as pexpect.run()
         # function.

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -52,9 +52,9 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         p.expect_exact(pexpect.EOF)
 
     def test_expect(self):
-        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
+        the_old_way = subprocess.Popen(args=['ls', '-l', '~'],
                                        stdout=subprocess.PIPE).communicate()[0].rstrip()
-        p = PopenSpawn('ls -l /bin')
+        p = PopenSpawn('ls -l ~')
         the_new_way = b''
         while 1:
             i = p.expect([b'\n', pexpect.EOF])
@@ -66,9 +66,9 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         assert the_old_way == the_new_way, len(the_old_way) - len(the_new_way)
 
     def test_expect_exact(self):
-        the_old_way = subprocess.Popen(args=['ls', '-l', '/bin'],
+        the_old_way = subprocess.Popen(args=['ls', '-l', '~'],
                                        stdout=subprocess.PIPE).communicate()[0].rstrip()
-        p = PopenSpawn('ls -l /bin')
+        p = PopenSpawn('ls -l ~')
         the_new_way = b''
         while 1:
             i = p.expect_exact([b'\n', pexpect.EOF])
@@ -85,9 +85,9 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(p.after, b'.?')
 
     def test_expect_eof(self):
-        the_old_way = subprocess.Popen(args=['/bin/ls', '-l', '/bin'],
+        the_old_way = subprocess.Popen(args=['ls', '-l', '~'],
                                        stdout=subprocess.PIPE).communicate()[0].rstrip()
-        p = PopenSpawn('/bin/ls -l /bin')
+        p = PopenSpawn('ls -l ~')
         # This basically tells it to read everything. Same as pexpect.run()
         # function.
         p.expect(pexpect.EOF)
@@ -100,7 +100,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(p.after, pexpect.TIMEOUT)
 
     def test_unexpected_eof(self):
-        p = PopenSpawn('ls -l /bin')
+        p = PopenSpawn('ls -l ~')
         try:
             p.expect('_Z_XY_XZ')  # Probably never see this in ls output.
         except pexpect.EOF:


### PR DESCRIPTION
This will ultimately allow simple uses of Pexpect on Windows. Ping @blink1073 - I copied your gist for the implementation of this.

Open questions:

- At present, `__init__.py` imports `pty_spawn`, so you can't even load Pexpect on Windows. I started doing something along the lines of:

```python
if sys.platform == 'win32':
    from .popen_spawn import PopenSpawn as spawn
else:
    from .pty_spawn import spawn
```

But that didn't feel quite right; an apparently similar API would be doing something very different internally, which would doubtless lead to surprising bugs. Maybe on Windows the top-level package simply shouldn't have `spawn` and `spawnu`, and we'll leave them in place on Unix for backwards compatibility.

- I'm aiming to make it as close as possible to the applicable parts of the pty_spawn API, but in a couple of places, the Unixy nature of that API conflicts with Popen and cross platform support:
   1. `spawn.kill()` takes a signal number. `Popen()` has `.kill()` and `.terminate()`, which send fixed Unix signals (SIGKILL and SIGTERM), and both do TerminateProcess on Windows.
   2. `spawn.wait()` returns the raw exit code, a 2-byte number where the high byte is the terminating signal number. `Popen.wait()` uses negative numbers for terminating signals.

   My inclination in these cases is that PopenSpawn should stay closer to the cross platform API of Popen, rather than trying to closely copy the pty_spawn interface and being inconsistent between platforms.