### PR TITLE
Increase timeout of replwrap test from 2=>5

### DIFF
--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -26,7 +26,7 @@ class REPLWrapTestCase(unittest.TestCase):
         assert 'real' in res, res
 
         # PAGER should be set to cat, otherwise man hangs
-        res = bash.run_command('man sleep', timeout=2)
+        res = bash.run_command('man sleep', timeout=5)
         assert 'SLEEP' in res, res
 
     def test_multiline(self):


### PR DESCRIPTION
The OSX build slave is almost as bad as travis, its very
sluggish -- Anyway this timeout condition occurs
intermittently presumably because it is too short

https://teamcity-master.pexpect.org/viewLog.html?buildId=782&buildTypeId=Pexpect_MacOs&tab=buildLog#_focus=499
