### PR TITLE
Resolve EOF error in test_interact.py for OSX and SunOs

### DIFF
--- a/tests/echo_w_prompt.py
+++ b/tests/echo_w_prompt.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-import codecs
-import sys
-
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
-sys.stderr = codecs.getwriter('utf8')(sys.stderr)
-
 
 try:
     raw_input

--- a/tests/interact_unicode.py
+++ b/tests/interact_unicode.py
@@ -11,11 +11,7 @@ except ImportError:
 
 from utils import no_coverage_env
 import pexpect
-import codecs
 import sys
-
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
-sys.stderr = codecs.getwriter('utf8')(sys.stderr)
 
 
 def main():


### PR DESCRIPTION
I've exported LANG=en_US.UTF-8 in the TeamCity build configuration itself, which allows the master branch to pass.

This pull request displays the current locale as part of tools/display-terminalinfo.py and enforces it in tools/teamcity-runtests.sh as well.

I've also re-enabled email notifications from TeamCity.
