### PR TITLE
Allows also method callback for events argument in pexpect.run()

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -206,7 +206,8 @@ def _run(command, timeout, withexitstatus, events, extra_args, logfile, cwd,
                 child_result_list.append(child.before)
             if isinstance(responses[index], child.allowed_string_types):
                 child.send(responses[index])
-            elif isinstance(responses[index], types.FunctionType):
+            elif isinstance(responses[index], types.FunctionType) or \
+                 isinstance(responses[index], types.MethodType):
                 callback_result = responses[index](locals())
                 sys.stdout.flush()
                 if isinstance(callback_result, child.allowed_string_types):

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -215,7 +215,7 @@ def _run(command, timeout, withexitstatus, events, extra_args, logfile, cwd,
                 elif callback_result:
                     break
             else:
-                raise TypeError('The callback must be a string or function.')
+                raise TypeError('The callback must be a string, function or method.')
             event_count = event_count + 1
         except TIMEOUT:
             child_result_list.append(child.before)


### PR DESCRIPTION
As discussed here https://github.com/pexpect/pexpect/issues/176
I didn't opt for `callable()` since it can include other cases (not tested here).

I updated test_run.py for this feature.