### PR TITLE
Support MethodType as callback for pexpect.run(event=...)

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -12,6 +12,8 @@ Version 4.0
   coroutine. You can get the result using ``yield from``, or wrap it in an
   :class:`asyncio.Task`. This allows the event loop to do other things while
   waiting for output that matches a pattern.
+* Enhancement: allow method as callbacks of argument ``events`` for
+  :func:`pexpect.run` (:ghissue:`176`).
 
 Version 3.4
 ```````````

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -71,7 +71,7 @@ from .utils import split_command_line, which, is_executable_file
 from .pty_spawn import spawn, spawnu, PY3
 from .expect import Expecter, searcher_re, searcher_string
 
-__version__ = '3.3'
+__version__ = '4.0.dev'
 __revision__ = ''
 __all__ = ['ExceptionPexpect', 'EOF', 'TIMEOUT', 'spawn', 'spawnu', 'run', 'runu',
            'which', 'split_command_line', '__version__', '__revision__']

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -149,8 +149,8 @@ def run(command, timeout=30, withexitstatus=False, events=None,
 
     Note that you should put newlines in your string if Enter is necessary.
 
-    Like the example above, the responses may also contain callback functions.
-    Any callback is a function that takes a dictionary as an argument.
+    Like the example above, the responses may also contain a callback, either
+    a function or method.  It should accept a dictionary value as an argument.
     The dictionary contains all the locals from the run() function, so you can
     access the child spawn object or any other variable defined in run()
     (event_count, child, and extra_args are the most useful). A callback may

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -206,8 +206,8 @@ def _run(command, timeout, withexitstatus, events, extra_args, logfile, cwd,
                 child_result_list.append(child.before)
             if isinstance(responses[index], child.allowed_string_types):
                 child.send(responses[index])
-            elif isinstance(responses[index], types.FunctionType) or \
-                 isinstance(responses[index], types.MethodType):
+            elif (isinstance(responses[index], types.FunctionType) or
+                  isinstance(responses[index], types.MethodType)):
                 callback_result = responses[index](locals())
                 sys.stdout.flush()
                 if isinstance(callback_result, child.allowed_string_types):

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -215,7 +215,9 @@ def _run(command, timeout, withexitstatus, events, extra_args, logfile, cwd,
                 elif callback_result:
                     break
             else:
-                raise TypeError('The callback must be a string, function or method.')
+                raise TypeError("parameter `event' at index {index} must be "
+                                "a string, method, or function: {value!r}"
+                                .format(index=index, value=responses[index]))
             event_count = event_count + 1
         except TIMEOUT:
             child_result_list.append(child.before)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -95,7 +95,7 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
             'ls -l /najoeufhdnzkxjd', withexitstatus=1)
         assert exitstatus != 0
 
-    def test_run_tuple_list(self):
+    def test_run_event_as_string(self):
         events = [
             # second match on 'abc', echo 'def'
             ('abc\r\n.*GO:', 'echo "def"\n'),
@@ -112,7 +112,7 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
             timeout=10)
         assert exitstatus == 0
 
-    def test_run_function(self):
+    def test_run_event_as_function(self):
         events = [
             ('GO:', function_events_callback)
         ]
@@ -124,9 +124,9 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
             timeout=10)
         assert exitstatus == 0
 
-    def test_run_method(self):
+    def test_run_event_as_method(self):
         events = [
-            ('GO:', self.method_events_callback)
+            ('GO:', self._method_events_callback)
         ]
 
         (data, exitstatus) = pexpect.run(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -144,9 +144,9 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
                         events=events,
                         timeout=10)
 
-    def _method_events_callback(self, d):
+    def _method_events_callback(self, values):
         try:
-            previous_echoed = (d["child_result_list"][-1].decode()
+            previous_echoed = (values["child_result_list"][-1].decode()
                                .split("\n")[-2].strip())
             if previous_echoed.endswith("foo1"):
                 return "echo foo2\n"
@@ -169,23 +169,23 @@ class RunUnicodeFuncTestCase(RunFuncTestCase):
 
     def test_run_unicode(self):
         if pexpect.PY3:
-            c = chr(254)   # þ
+            char = chr(254)   # þ
             pattern = '<in >'
         else:
-            c = unichr(254)  # analysis:ignore
+            char = unichr(254)  # analysis:ignore
             pattern = '<in >'.decode('ascii')
 
-        def callback(d):
-            if d['event_count'] == 0:
-                return c + '\n'
+        def callback(values):
+            if values['event_count'] == 0:
+                return char + '\n'
             else:
                 return True  # Stop the child process
 
         output = pexpect.runu(sys.executable + ' echo_w_prompt.py',
-                              env={'PYTHONIOENCODING':'utf-8'},
-                              events={pattern:callback})
+                              env={'PYTHONIOENCODING': 'utf-8'},
+                              events={pattern: callback})
         assert isinstance(output, unicode_type), type(output)
-        assert '<out>'+c in output, output
+        assert ('<out>' + char) in output, output
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -136,7 +136,15 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
             timeout=10)
         assert exitstatus == 0
 
-    def method_events_callback(self, d):
+    def test_run_event_typeerror(self):
+        events = [('GO:', -1)]
+        with self.assertRaises(TypeError):
+            pexpect.run('bash --rcfile {0}'.format(self.rcfile),
+                        withexitstatus=True,
+                        events=events,
+                        timeout=10)
+
+    def _method_events_callback(self, d):
         try:
             previous_echoed = (d["child_result_list"][-1].decode()
                                .split("\n")[-2].strip())


### PR DESCRIPTION
For your quick review, @takluyver: This supersedes PR #177 and closes issue #176.

**major**
- bumps ``__version__`` to 4.0.dev as discussed in https://github.com/pexpect/pexpect/issues/174
- allows a method to be used as an event callback for ``run()``

**minor**
- better TypeError for invalid callback types
- more coverage to include this TypeError, ``test_run_event_typeerror``
- enhance readability of ``test_run.py``
