### PR TITLE
'Unicode mode' in spawn class

### DIFF
--- a/doc/api/pexpect.rst
+++ b/doc/api/pexpect.rst
@@ -36,9 +36,9 @@ spawn class
 
       .. note::
 
-         With a :class:`spawn` instance, the log files should be open for
-         writing binary data. With a :class:`spawnu` instance, they should
-         be open for writing unicode text.
+         With :class:`spawn` in bytes mode, the log files should be open for
+         writing binary data. In unicode mode, they should
+         be open for writing unicode text. See :ref:`unicode`.
 
 Controlling the child process
 `````````````````````````````
@@ -69,30 +69,34 @@ Controlling the child process
 Handling unicode
 ````````````````
 
-For backwards compatibility, :class:`spawn` can handle some Unicode: its
+By default, :class:`spawn` is a bytes interface: its read methods return bytes,
+and its write/send and expect methods expect bytes. If you pass the *encoding*
+parameter to the constructor, it will instead act as a unicode interface:
+strings you send will be encoded using that encoding, and bytes received will
+be decoded before returning them to you. In this mode, patterns for
+:meth:`~spawn.expect` and :meth:`~spawn.expect_exact` should also be unicode.
+
+.. versionchanged:: 4.0
+
+   :class:`spawn` provides both the bytes and unicode interfaces. In Pexpect
+   3.x, the unicode interface was provided by a separate ``spawnu`` class.
+
+For backwards compatibility, some Unicode is allowed in bytes mode: the
 send methods will encode arbitrary unicode as UTF-8 before sending it to the
 child process, and its expect methods can accept ascii-only unicode strings.
-However, for a proper unicode API to a subprocess, use this subclass:
-
-.. autoclass:: spawnu
-   :show-inheritance:
-
-There is also a :func:`runu` function, the unicode counterpart to :func:`run`.
 
 .. note::
 
    Unicode handling with pexpect works the same way on Python 2 and 3, despite
    the difference in names. I.e.:
 
-   - :class:`spawn` works with ``str`` on Python 2, and :class:`bytes` on Python 3,
-   - :class:`spawnu` works with ``unicode`` on Python 2, and :class:`str` on Python 3.
+   - Bytes mode works with ``str`` on Python 2, and :class:`bytes` on Python 3,
+   - Unicode mode works with ``unicode`` on Python 2, and :class:`str` on Python 3.
 
 run function
 ------------
 
 .. autofunction:: run
-
-.. autofunction:: runu
 
 Exceptions
 ----------

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -220,8 +220,9 @@ def runu(command, timeout=30, withexitstatus=False, events=None,
         extra_args=None, logfile=None, cwd=None, env=None, **kwargs):
     """Deprecated: pass encoding to run() instead.
     """
+    kwargs.setdefault('encoding', 'utf-8')
     return run(command, timeout=timeout, withexitstatus=withexitstatus,
                 events=events, extra_args=extra_args, logfile=logfile, cwd=cwd,
-                env=env, _spawn=spawnu, **kwargs)
+                env=env, **kwargs)
 
 # vim: set shiftround expandtab tabstop=4 shiftwidth=4 ft=python autoindent :

--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -77,7 +77,7 @@ __all__ = ['ExceptionPexpect', 'EOF', 'TIMEOUT', 'spawn', 'spawnu', 'run', 'runu
            'which', 'split_command_line', '__version__', '__revision__']
 
 def run(command, timeout=30, withexitstatus=False, events=None,
-        extra_args=None, logfile=None, cwd=None, env=None):
+        extra_args=None, logfile=None, cwd=None, env=None, **kwargs):
 
     '''
     This function runs the given command; waits for it to finish; then
@@ -159,29 +159,16 @@ def run(command, timeout=30, withexitstatus=False, events=None,
     sent to the child. 'extra_args' is not used by directly run(). It provides
     a way to pass data to a callback function through run() through the locals
     dictionary passed to a callback.
+
+    Like :class:`spawn`, passing *encoding* will make it work with unicode
+    instead of bytes. You can pass *codec_errors* to control how errors in
+    encoding and decoding are handled.
     '''
-    return _run(command, timeout=timeout, withexitstatus=withexitstatus,
-                events=events, extra_args=extra_args, logfile=logfile, cwd=cwd,
-                env=env, _spawn=spawn)
-
-def runu(command, timeout=30, withexitstatus=False, events=None,
-        extra_args=None, logfile=None, cwd=None, env=None, **kwargs):
-    """This offers the same interface as :func:`run`, but using unicode.
-
-    Like :class:`spawnu`, you can pass ``encoding`` and ``errors`` parameters,
-    which will be used for both input and output.
-    """
-    return _run(command, timeout=timeout, withexitstatus=withexitstatus,
-                events=events, extra_args=extra_args, logfile=logfile, cwd=cwd,
-                env=env, _spawn=spawnu, **kwargs)
-
-def _run(command, timeout, withexitstatus, events, extra_args, logfile, cwd,
-         env, _spawn, **kwargs):
     if timeout == -1:
-        child = _spawn(command, maxread=2000, logfile=logfile, cwd=cwd, env=env,
+        child = spawn(command, maxread=2000, logfile=logfile, cwd=cwd, env=env,
                         **kwargs)
     else:
-        child = _spawn(command, timeout=timeout, maxread=2000, logfile=logfile,
+        child = spawn(command, timeout=timeout, maxread=2000, logfile=logfile,
                 cwd=cwd, env=env, **kwargs)
     if isinstance(events, list):
         patterns= [x for x,y in events]
@@ -228,5 +215,13 @@ def _run(command, timeout, withexitstatus, events, extra_args, logfile, cwd,
         return (child_result, child.exitstatus)
     else:
         return child_result
+
+def runu(command, timeout=30, withexitstatus=False, events=None,
+        extra_args=None, logfile=None, cwd=None, env=None, **kwargs):
+    """Deprecated: pass encoding to run() instead.
+    """
+    return run(command, timeout=timeout, withexitstatus=withexitstatus,
+                events=events, extra_args=extra_args, logfile=logfile, cwd=cwd,
+                env=env, _spawn=spawnu, **kwargs)
 
 # vim: set shiftround expandtab tabstop=4 shiftwidth=4 ft=python autoindent :

--- a/pexpect/async.py
+++ b/pexpect/async.py
@@ -36,7 +36,7 @@ class PatternWaiter(asyncio.Protocol):
     
     def data_received(self, data):
         spawn = self.expecter.spawn
-        s = spawn._coerce_read_string(data)
+        s = spawn._decoder.decode(data)
         spawn._log(s, 'read')
 
         if self.fut.done():


### PR DESCRIPTION
As discussed, this makes unicode vs. bytes two modes within spawn, rather than separate classes. There are various spawn classes for other purposes, and we were heading towards having fiddly multiple inheritance to get pxsshu, fdspawnu, etc.

I've left `spawnu` and `runu` as wrapper functions for backwards compatibility, but marked them deprecated and removed them from docs. They could alternatively be left as convenience functions: `spawnu(...)` is a bit less typing than `spawn(..., encoding='utf-8')`. I don't have a strong preference on this, but I've left updating the tests until we make a decision on this.

Also still to do: expose the encoding & codec_errors parameters on pxssh, fdspawn, and anything else that may need them.

Testing this requires the corresponding branch of ptyprocess (pexpect/ptyprocess#10).