### PR TITLE
Allow specifying screen size for the subprocess in pexpect.spawn().

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -77,7 +77,7 @@ __all__ = ['ExceptionPexpect', 'EOF', 'TIMEOUT', 'spawn', 'spawnu', 'run', 'runu
            'which', 'split_command_line', '__version__', '__revision__']
 
 def run(command, timeout=30, withexitstatus=False, events=None,
-        extra_args=None, logfile=None, cwd=None, env=None):
+        extra_args=None, logfile=None, cwd=None, env=None, dimensions=None):
 
     '''
     This function runs the given command; waits for it to finish; then
@@ -162,7 +162,7 @@ def run(command, timeout=30, withexitstatus=False, events=None,
     '''
     return _run(command, timeout=timeout, withexitstatus=withexitstatus,
                 events=events, extra_args=extra_args, logfile=logfile, cwd=cwd,
-                env=env, _spawn=spawn)
+                env=env,dimensions=dimensions, _spawn=spawn)
 
 def runu(command, timeout=30, withexitstatus=False, events=None,
         extra_args=None, logfile=None, cwd=None, env=None, **kwargs):

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -37,7 +37,8 @@ class spawn(SpawnBase):
 
     def __init__(self, command, args=[], timeout=30, maxread=2000,
                  searchwindowsize=None, logfile=None, cwd=None, env=None,
-                 ignore_sighup=True, echo=True, preexec_fn=None):
+                 ignore_sighup=True, echo=True, preexec_fn=None,
+                 dimensions=None):
         '''This is the constructor. The command parameter may be a string that
         includes a command and any arguments to the command. For example::
 
@@ -170,6 +171,10 @@ class spawn(SpawnBase):
         If preexec_fn is given, it will be called in the child process before
         launching the given command. This is useful to e.g. reset inherited
         signal handlers.
+
+        The dimensions attribute specifies the size of the pseudo-terminal as
+        seen by the subprocess, and is specified as a two-entry tuple (rows,
+        columns). If this is unspecified, the defaults in ptyprocess will apply.
         '''
         super(spawn, self).__init__(timeout=timeout, maxread=maxread, searchwindowsize=searchwindowsize,
                                     logfile=logfile)
@@ -186,7 +191,7 @@ class spawn(SpawnBase):
             self.args = None
             self.name = '<pexpect factory incomplete>'
         else:
-            self._spawn(command, args, preexec_fn)
+            self._spawn(command, args, preexec_fn, dimensions)
 
     def __str__(self):
         '''This returns a human-readable string that represents the state of
@@ -222,7 +227,7 @@ class spawn(SpawnBase):
         s.append('delayafterterminate: ' + str(self.delayafterterminate))
         return '\n'.join(s)
 
-    def _spawn(self, command, args=[], preexec_fn=None):
+    def _spawn(self, command, args=[], preexec_fn=None, dimensions=None):
         '''This starts the given command in a child process. This does all the
         fork/exec type of stuff for a pty. This is called by __init__. If args
         is empty then command will be parsed (split on spaces) and args will be
@@ -276,6 +281,9 @@ class spawn(SpawnBase):
                 if preexec_fn is not None:
                     preexec_fn()
             kwargs['preexec_fn'] = preexec_wrapper
+
+        if dimensions is not None:
+            kwargs['dimensions'] = dimensions
 
         self.ptyproc = self.ptyprocess_class.spawn(self.args, env=self.env,
                                                    cwd=self.cwd, **kwargs)


### PR DESCRIPTION
This is related to [`ptyprocess` PR #11](https://github.com/pexpect/ptyprocess/pull/11). It allows setting the screen size for the spawned subprocess.