### PR TITLE
Set `flag_eof` in expect.py when raising EOF. Fixes #200.

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -46,6 +46,7 @@ class Expecter(object):
             msg = str(spawn)
             if err is not None:
                 msg = str(err) + '\n' + msg
+            spawn.flag_eof = True
             raise EOF(msg)
     
     def timeout(self, err=None):


### PR DESCRIPTION
Not 100% sure this is the right thing to do, but it works.