### PR TITLE
Do not raise Exception on wait() after terminate or previous wait()

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -14,6 +14,9 @@ Version 4.0
   waiting for output that matches a pattern.
 * Enhancement: allow method as callbacks of argument ``events`` for
   :func:`pexpect.run` (:ghissue:`176`).
+* It is now possible to call :meth:`~.wait` multiple times, or after a process
+  is already determined to be terminated without raising an exception
+  (:ghpull:`211`).
 
 Version 3.4
 ```````````

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -614,10 +614,17 @@ class spawn(SpawnBase):
         not read any data from the child, so this will block forever if the
         child has unread output and has terminated. In other words, the child
         may have printed output then called exit(), but, the child is
-        technically still alive until its output is read by the parent. '''
+        technically still alive until its output is read by the parent.
+
+        This method is non-blocking if :meth:`wait` has already been called
+        previously or :meth:`isalive` method returns False.  It simply returns
+        the previously determined exit status.
+        '''
 
         ptyproc = self.ptyproc
         with _wrap_ptyprocess_err():
+            # exception may occur if "Is some other process attempting
+            # "job control with our child pid?"
             exitstatus = ptyproc.wait()
         self.status = ptyproc.status
         self.exitstatus = ptyproc.exitstatus

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup (name='pexpect',
         'Topic :: System :: Software Distribution',
         'Topic :: Terminals',
     ],
-    install_requires=['ptyprocess'],
+    install_requires=['ptyprocess>=0.5'],
 )


### PR DESCRIPTION
This matches the same branch of ptyprocess, https://github.com/pexpect/ptyprocess/pull/18 from @reynir, ``noexception-on-wait-after-terminate``, which allows calling the wait() method multiple times without raising an exception.

There is no logical change, only a docstring and adjustments to (otherwise failing) test cases.

(@takluyver:  Note that TeamCity comprehends "pairing branch names" across these two repositories and tests them accordingly, but Travis-CI does not (so the test will fail, here). Created issue #210 to address.

Furthermore, described in https://github.com/pexpect/pexpect/commit/4bd7305df7a582887db7202128f285a2970aca6f it is now necessary to specify ``>=0.5`` requirement of ptyprocess.  In this particular case, It isn't terribly harmful, but it is good to start.  This too will break the travis-ci build, which would be resolved by release of ptyprocess 0.5 or issue #210)