### PR TITLE
Do we really need 'time.sleep()' in expect_loop?

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -1537,7 +1537,7 @@ class spawn(object):
                 # Still have time left, so read more data
                 c = self.read_nonblocking(self.maxread, timeout)
                 freshlen = len(c)
-                time.sleep(0.0001)
+                #time.sleep(0.0001)
                 incoming = incoming + c
                 if timeout is not None:
                     timeout = end_time - time.time()


### PR DESCRIPTION
https://github.com/pexpect/pexpect/issues/215