### PR TITLE
Do we really need 'time.sleep()'?

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -95,6 +95,7 @@ class Expecter(object):
                     return self.timeout()
                 # Still have time left, so read more data
                 incoming = spawn.read_nonblocking(spawn.maxread, timeout)
+                time.sleep(0)
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:

--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -95,7 +95,6 @@ class Expecter(object):
                     return self.timeout()
                 # Still have time left, so read more data
                 incoming = spawn.read_nonblocking(spawn.maxread, timeout)
-                time.sleep(0.0001)
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:

--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -95,7 +95,7 @@ class Expecter(object):
                     return self.timeout()
                 # Still have time left, so read more data
                 incoming = spawn.read_nonblocking(spawn.maxread, timeout)
-                time.sleep(0)
+                time.sleep(0.0001)
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:


### PR DESCRIPTION
https://github.com/pexpect/pexpect/issues/215

Tried this on 3.x branch but ci testing apparently does not work on 3.x, so here we are again against master branch.