### PR TITLE
Remove separate top-level modules

### DIFF
--- a/ANSI.py
+++ b/ANSI.py
@@ -1,7 +1,0 @@
-import warnings
-
-warnings.warn("This module has been moved to pexpect.ANSI, please update imports.",
-                ImportWarning)
-del warnings
-
-from pexpect.ANSI import *  # analysis:ignore

--- a/FSM.py
+++ b/FSM.py
@@ -1,7 +1,0 @@
-import warnings
-
-warnings.warn("This module has been moved to pexpect.FSM, please update imports.",
-                ImportWarning)
-del warnings
-
-from pexpect.FSM import *  # analysis:ignore

--- a/fdpexpect.py
+++ b/fdpexpect.py
@@ -1,7 +1,0 @@
-import warnings
-
-warnings.warn("This module has been moved to pexpect.fdpexpect, please update imports.",
-                ImportWarning)
-del warnings
-
-from pexpect.fdpexpect import *  # analysis:ignore

--- a/pxssh.py
+++ b/pxssh.py
@@ -1,7 +1,0 @@
-import warnings
-
-warnings.warn("This module has been moved to pexpect.pxssh, please update imports.",
-                ImportWarning)
-del warnings
-
-from pexpect.pxssh import *  # analysis:ignore

--- a/screen.py
+++ b/screen.py
@@ -1,7 +1,0 @@
-import warnings
-
-warnings.warn("This module has been moved to pexpect.screen, please update imports.",
-                ImportWarning)
-del warnings
-
-from pexpect.screen import *  # analysis:ignore

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ The Pexpect interface was designed to be easy to use.
 
 setup (name='pexpect',
     version=version,
-    py_modules=['pxssh', 'fdpexpect', 'FSM', 'screen', 'ANSI'],
     packages=['pexpect'],
     description='Pexpect allows easy control of interactive console applications.',
     long_description=long_description,


### PR DESCRIPTION
These were deprecated in 3.x, moving them into the Pexpect package. This removes them entirely for 4.x.