### PR TITLE
Encoding parameters for pxssh and fdspawn

### DIFF
--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -32,7 +32,8 @@ class fdspawn(SpawnBase):
     descriptor. For example, you could use it to read through a file looking
     for patterns, or to control a modem or serial device. '''
 
-    def __init__ (self, fd, args=None, timeout=30, maxread=2000, searchwindowsize=None, logfile=None):
+    def __init__ (self, fd, args=None, timeout=30, maxread=2000, searchwindowsize=None,
+                  logfile=None, encoding=None, codec_errors='strict'):
         '''This takes a file descriptor (an int) or an object that support the
         fileno() method (returning an int). All Python file-like objects
         support fileno(). '''
@@ -50,7 +51,8 @@ class fdspawn(SpawnBase):
 
         self.args = None
         self.command = None
-        SpawnBase.__init__(self, timeout, maxread, searchwindowsize, logfile)
+        SpawnBase.__init__(self, timeout, maxread, searchwindowsize, logfile,
+                           encoding=encoding, codec_errors=codec_errors)
         self.child_fd = fd
         self.own_fd = False
         self.closed = False
@@ -93,7 +95,8 @@ class fdspawn(SpawnBase):
         s = self._coerce_send_string(s)
         self._log(s, 'send')
         
-        return os.write(self.child_fd, s)
+        b = self._encoder.encode(s, final=False)
+        return os.write(self.child_fd, b)
     
     def sendline(self, s):
         "Write to fd with trailing newline, return number of bytes written"

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -117,7 +117,7 @@ class spawn(SpawnBase):
             child = pexpect.spawn('some_command')
             child.logfile_read = sys.stdout
 
-        Remember to use spawnu instead of spawn for the above code if you are
+        You will need to pass an encoding to spawn in the above code if you are
         using Python 3.
 
         To separately log output sent to the child use logfile_send::

--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -172,7 +172,7 @@ class pxssh (spawn):
         # maximum time for reading the entire prompt
         total_timeout = timeout_multiplier * 3.0
 
-        prompt = b''
+        prompt = self.string_type()
         begin = time.time()
         expired = 0.0
         timeout = first_char_timeout

--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -95,9 +95,12 @@ class pxssh (spawn):
 
     def __init__ (self, timeout=30, maxread=2000, searchwindowsize=None,
                     logfile=None, cwd=None, env=None, ignore_sighup=True, echo=True,
-                    options={}):
+                    options={}, encoding=None, codec_errors='strict'):
 
-        spawn.__init__(self, None, timeout=timeout, maxread=maxread, searchwindowsize=searchwindowsize, logfile=logfile, cwd=cwd, env=env, ignore_sighup=ignore_sighup, echo=echo)
+        spawn.__init__(self, None, timeout=timeout, maxread=maxread,
+                       searchwindowsize=searchwindowsize, logfile=logfile,
+                       cwd=cwd, env=env, ignore_sighup=ignore_sighup, echo=echo,
+                       encoding=encoding, codec_errors=codec_errors)
 
         self.name = '<pxssh>'
 


### PR DESCRIPTION
Allows them to provide a unicode interface in the same manner as spawn.

Merging this will close #92, #169 and #172.