### PR TITLE
Allow {p}.interact(escape_character=None)

### DIFF
--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -686,7 +686,7 @@ class spawn(SpawnBase):
         it echos the real stdin to the child stdin. When the user types the
         escape_character this method will return None. The escape_character
         will not be transmitted.  The default for escape_character is
-        entered as ``Ctrl - ]``, the very same for bsd telnet. To prevent
+        entered as ``Ctrl - ]``, the very same as BSD telnet. To prevent
         escaping, escape_character may be set to None.
 
         You may pass in optional input and output filter functions. These

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -684,11 +684,10 @@ class spawn(SpawnBase):
         the stdout and stderr output of the child process is printed. This
         simply echos the child stdout and child stderr to the real stdout and
         it echos the real stdin to the child stdin. When the user types the
-        escape_character this method will stop. The default for
-        escape_character is ^]. This should not be confused with ASCII 27 --
-        the ESC character. ASCII 29 was chosen for historical merit because
-        this is the character used by 'telnet' as the escape character. The
-        escape_character will not be sent to the child process.
+        escape_character this method will return None. The escape_character
+        will not be transmitted.  The default for escape_character is
+        entered as ``Ctrl - ]``, the very same for bsd telnet. To prevent
+        escaping, escape_character may be set to None.
 
         You may pass in optional input and output filter functions. These
         functions should take a string and return a string. The output_filter
@@ -720,7 +719,7 @@ class spawn(SpawnBase):
         self.buffer = self.string_type()
         mode = tty.tcgetattr(self.STDIN_FILENO)
         tty.setraw(self.STDIN_FILENO)
-        if PY3:
+        if escape_character is not None and PY3:
             escape_character = escape_character.encode('latin-1')
         try:
             self.__interact_copy(escape_character, input_filter, output_filter)
@@ -770,7 +769,9 @@ class spawn(SpawnBase):
                 data = self.__interact_read(self.STDIN_FILENO)
                 if input_filter:
                     data = input_filter(data)
-                i = data.rfind(escape_character)
+                i = -1
+                if escape_character is not None:
+                    i = data.rfind(escape_character)
                 if i != -1:
                     data = data[:i]
                     self.__interact_writen(self.child_fd, data)

--- a/tests/getch.py
+++ b/tests/getch.py
@@ -18,6 +18,7 @@ PEXPECT LICENSE
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 '''
+from __future__ import print_function
 import sys, tty, termios
 
 if hasattr(sys.stdin, 'buffer'):
@@ -27,13 +28,13 @@ else:
     stdin = sys.stdin
 
 def main():
-    print('READY')
+    print('READY', end='\r\n')
     while True:
         try:
             val = ord(stdin.read(1))
         except KeyboardInterrupt:
             val = 3
-        sys.stdout.write('%d<STOP>\r\n' % (val,))
+        print('%d<STOP>' % (val,), end='\r\n')
         if val == 0:
             # StopIteration equivalent is ctrl+' ' (\x00, NUL)
             break

--- a/tests/interact.py
+++ b/tests/interact.py
@@ -33,7 +33,10 @@ import sys
 def main():
     p = pexpect.spawn(sys.executable + ' echo_w_prompt.py',
                       env=no_coverage_env())
-    p.interact()
+    escape_character = chr(29)  # default matches api
+    if len(sys.argv) > 2 and sys.argv[1] == '--no-escape':
+        escape_character = None
+    p.interact(escape_character=escape_character)
     print("Escaped interact")
 
 if __name__ == '__main__':

--- a/tests/interact.py
+++ b/tests/interact.py
@@ -34,7 +34,7 @@ def main():
     p = pexpect.spawn(sys.executable + ' echo_w_prompt.py',
                       env=no_coverage_env())
     escape_character = chr(29)  # default matches api
-    if len(sys.argv) > 2 and sys.argv[1] == '--no-escape':
+    if len(sys.argv) > 1 and sys.argv[1] == '--no-escape':
         escape_character = None
     p.interact(escape_character=escape_character)
     print("Escaped interact")

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -62,6 +62,9 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         p = pexpect.spawn('{self.interact_py} --no-escape'.format(self=self),
                           timeout=5, env=self.env)
         p.expect('<in >')
+        p.sendcontrol(']')
+        p.sendline('')
+        p.expect('<out>\x1d')
         p.sendcontrol('d')
         p.expect('<eof>')
         p.expect_exact('Escaped interact')

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -57,6 +57,18 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         assert not p.isalive()
         assert p.exitstatus == 0
 
+    def test_interact_escape_None(self):
+        " Return only after Termination when `escape_character=None'. "
+        p = pexpect.spawn('{self.interact_py} --no-escape'.format(self=self),
+                          timeout=5, env=self.env)
+        p.expect('<in >')
+        p.sendcontrol('d')
+        p.expect('<eof>')
+        p.expect_exact('Escaped interact')
+        p.expect(pexpect.EOF)
+        assert not p.isalive()
+        assert p.exitstatus == 0
+
     def test_interact_spawn_eof(self):
         " Ensure subprocess receives EOF and exit. "
         p = pexpect.spawn(self.interact_py, timeout=5, env=self.env)


### PR DESCRIPTION
For those who wish to disable the ability to escape using (likely, human) input until normal process termination, they may now set the value of escape_character to None.

Some of the related docstring on escape_character was made more
brief and clear about its related value behavior.

This closes #131 #132 #167 