### PR TITLE
Use ^C test_interact_escape_None, ^D unreliable

### DIFF
--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -26,7 +26,6 @@ import os
 import pexpect
 import unittest
 import sys
-import platform
 from . import PexpectTestCase
 
 
@@ -66,9 +65,7 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         p.sendcontrol(']')
         p.sendline('')
         p.expect('<out>\x1d')
-        p.sendcontrol('d')
-        if platform.python_implementation() != 'PyPy':
-            p.expect('<eof>')
+        p.sendcontrol('c')
         p.expect_exact('Escaped interact')
         p.expect(pexpect.EOF)
         assert not p.isalive()

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -26,6 +26,7 @@ import os
 import pexpect
 import unittest
 import sys
+import platform
 from . import PexpectTestCase
 
 
@@ -66,7 +67,8 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         p.sendline('')
         p.expect('<out>\x1d')
         p.sendcontrol('d')
-        p.expect('<eof>')
+        if platform.python_implementation() != 'PyPy':
+            p.expect('<eof>')
         p.expect_exact('Escaped interact')
         p.expect(pexpect.EOF)
         assert not p.isalive()


### PR DESCRIPTION
Test intermittently fails PyPy and Travis-CI hosts, where EOF ins incorrectly interpreted instead of captured as exception.