### PR TITLE
Honor 'force=False' when set on p.close()

### DIFF
--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -295,7 +295,7 @@ class spawn(SpawnBase):
         and SIGINT). '''
 
         self.flush()
-        self.ptyproc.close()
+        self.ptyproc.close(force=force)
         self.isalive()  # Update exit status from ptyproc
         self.child_fd = -1
 


### PR DESCRIPTION
This has no change, both this method and ptyprocess
method signatures match 'True' value.