### PR TITLE
Unicode argv tests

### DIFF
--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -177,7 +177,7 @@ class UnicodeTests(PexpectTestCase.PexpectTestCase):
         """ Ensure a program can be executed with unicode arguments. """
         p = pexpect.spawn(u'{self.PYTHONBIN} sleep_for.py ǝpoɔıun'
                           .format(self=self), timeout=5, encoding='utf8')
-        p.expect_exact(u'could not convert string to float: ǝpoɔıun')
+        p.expect(u'could not convert string to float:.*ǝpoɔıun')
         p.expect(pexpect.EOF)
         assert not p.isalive()
         assert p.exitstatus != 0  # child process could not convert to float

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -177,7 +177,8 @@ class UnicodeTests(PexpectTestCase.PexpectTestCase):
         """ Ensure a program can be executed with unicode arguments. """
         p = pexpect.spawn(u'{self.PYTHONBIN} sleep_for.py ǝpoɔıun'
                           .format(self=self), timeout=5, encoding='utf8')
-        p.expect(u'could not convert string to float:.*ǝpoɔıun')
+        p.expect(u'(could not convert string to float:.*ǝpoɔıun'  # py2.7/3.4
+                 u'|invalid literal for float():.*ǝpoɔıun)')      # pypy !?
         p.expect(pexpect.EOF)
         assert not p.isalive()
         assert p.exitstatus != 0  # child process could not convert to float

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -173,6 +173,15 @@ class UnicodeTests(PexpectTestCase.PexpectTestCase):
         # exercise,
         assert child.readline() == 'input' + child.crlf
 
+    def test_unicode_argv(self):
+        """ Ensure a program can be executed with unicode arguments. """
+        p = pexpect.spawn(u'{self.PYTHONBIN} sleep_for.py ǝpoɔıun'
+                          .format(self=self), timeout=5, encoding='utf8')
+        p.expect_exact(u'could not convert string to float: ǝpoɔıun')
+        p.expect(pexpect.EOF)
+        assert not p.isalive()
+        assert p.exitstatus != 0  # child process could not convert to float
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -175,18 +175,12 @@ class UnicodeTests(PexpectTestCase.PexpectTestCase):
 
     def test_unicode_argv(self):
         """ Ensure a program can be executed with unicode arguments. """
-        p = pexpect.spawn(u'{self.PYTHONBIN} sleep_for.py ǝpoɔıun'
-                          .format(self=self), timeout=5, encoding='utf8')
-        # we expect the program to error, and display a ValueError for the
-        # float literal. It will also print it back to us, with the exception
-        # of PyPy, which seems to use a form of repr() of the bytestream.
-        if platform.python_implementation() == 'PyPy':
-            p.expect(u'ǝpoɔıun')
-        else:
-            p.expect(ur'\\xc7\\x9dpo\\xc9\\x94\\xc4\\xb1un')
+        p = pexpect.spawn(u'echo ǝpoɔıun'.format(self=self),
+                          timeout=5, encoding='utf8')
+        p.expect(u'ǝpoɔıun')
         p.expect(pexpect.EOF)
         assert not p.isalive()
-        assert p.exitstatus != 0  # child process could not convert to float
+        assert p.exitstatus == 0
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -177,8 +177,13 @@ class UnicodeTests(PexpectTestCase.PexpectTestCase):
         """ Ensure a program can be executed with unicode arguments. """
         p = pexpect.spawn(u'{self.PYTHONBIN} sleep_for.py ǝpoɔıun'
                           .format(self=self), timeout=5, encoding='utf8')
-        p.expect(u'(could not convert string to float:.*ǝpoɔıun'  # py2.7/3.4
-                 u'|invalid literal for float():.*ǝpoɔıun)')      # pypy !?
+        # we expect the program to error, and display a ValueError for the
+        # float literal. It will also print it back to us, with the exception
+        # of PyPy, which seems to use a form of repr() of the bytestream.
+        if platform.python_implementation() == 'PyPy':
+            p.expect(u'ǝpoɔıun')
+        else:
+            p.expect(ur'\\xc7\\x9dpo\\xc9\\x94\\xc4\\xb1un')
         p.expect(pexpect.EOF)
         assert not p.isalive()
         assert p.exitstatus != 0  # child process could not convert to float

--- a/tests/test_which.py
+++ b/tests/test_which.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import subprocess
 import tempfile
 import shutil
@@ -21,9 +22,13 @@ class TestCaseWhich(PexpectTestCase.PexpectTestCase):
 
     def test_os_defpath_which(self):
         " which() finds an executable in $PATH and returns its abspath. "
-        fname = 'cc'
+
         bin_dir = tempfile.mkdtemp()
-        bin_path = os.path.join(bin_dir, fname)
+        temp_obj = tempfile.NamedTemporaryFile(
+            suffix=u'.sh', prefix=u'ǝpoɔıun-',
+            dir=bin_dir, delete=False)
+        bin_path = temp_obj.name
+        fname = os.path.basename(temp_obj.name)
         save_path = os.environ['PATH']
         save_defpath = os.defpath
 


### PR DESCRIPTION
Add two test cases. One to ensure which() can match a unicode filename, and another to ensure 'argument splitting' over unicode works fine and is received by the child process in the expected encoding. 