### PR TITLE
Change ignore_sighup default to False

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -17,16 +17,23 @@ Version 4.0
 * It is now possible to call :meth:`~.wait` multiple times, or after a process
   is already determined to be terminated without raising an exception
   (:ghpull:`211`).
-* Deprecated ``pexpect.screen`` and ``pexpect.ANSI``. Please use other packages
-  such as `pyte <https://pypi.python.org/pypi/pyte>`__ to emulate a terminal.
-* Removed the independent top-level modules (``pxssh fdpexpect FSM screen ANSI``)
-  which were installed alongside Pexpect. These were moved into the Pexpect
-  package in 3.0, but the old names were left as aliases.
 * Fix regression that prevented executable, but unreadable files from
   being found when not specified by absolute path -- such as
   /usr/bin/sudo (:ghissue:`104`).
 * Fixed regression when executing pexpect with some prior releases of
   the multiprocessing module where stdin has been closed (:ghissue:`86`).
+
+Backwards incompatible changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Deprecated ``pexpect.screen`` and ``pexpect.ANSI``. Please use other packages
+  such as `pyte <https://pypi.python.org/pypi/pyte>`__ to emulate a terminal.
+* Removed the independent top-level modules (``pxssh fdpexpect FSM screen ANSI``)
+  which were installed alongside Pexpect. These were moved into the Pexpect
+  package in 3.0, but the old names were left as aliases.
+* Child processes created by Pexpect no longer ignore SIGHUP by default: the
+  ``ignore_sighup`` parameter of :class:`pexpect.spawn` defaults to False. To
+  get the old behaviour, pass ``ignore_sighup=True``.
 
 Version 3.3
 ```````````

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -36,7 +36,7 @@ class spawn(SpawnBase):
 
     def __init__(self, command, args=[], timeout=30, maxread=2000,
                  searchwindowsize=None, logfile=None, cwd=None, env=None,
-                 ignore_sighup=True, echo=True, preexec_fn=None,
+                 ignore_sighup=False, echo=True, preexec_fn=None,
                  encoding=None, codec_errors='strict'):
         '''This is the constructor. The command parameter may be a string that
         includes a command and any arguments to the command. For example::
@@ -122,9 +122,8 @@ class spawn(SpawnBase):
             child.logfile_send = fout
 
         If ``ignore_sighup`` is True, the child process will ignore SIGHUP
-        signals. For now, the default is True, to preserve the behaviour of
-        earlier versions of Pexpect, but you should pass this explicitly if you
-        want to rely on it.
+        signals. The default is False from Pexpect 4.0, meaning that SIGHUP
+        will be handled normally by the child.
 
         The delaybeforesend helps overcome a weird behavior that many users
         were experiencing. The typical problem was that a user would expect() a


### PR DESCRIPTION
This means child processes will no longer ignore SIGHUP by default.

Also pulled out a 'backwards incompatible changes' section of the release notes to make it clearer what has changed.

Closes gh-168