### PR TITLE
Remove non-ascii characters breaking easy_install for python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ automated software testing. Pexpect is in the spirit of Don Libes' Expect, but
 Pexpect is pure Python.
 
 The main features of Pexpect require the pty module in the Python standard
-library, which is only available on Unix-like systems. Some features—waiting
-for patterns from file descriptors or subprocesses—are also available on
+library, which is only available on Unix-like systems. Some features waiting
+for patterns from file descriptors or subprocesses are also available on
 Windows.
 """
 


### PR DESCRIPTION
The other solution would be to add an encoding header.

When trying to easy_install pexpect (or load the setup.py file directly with python 2.7) you will get:

SyntaxError: Non-ASCII character '\xe2' in file setup.py on line 28, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

The characters seem unecessary so I just removed them.