### PR TITLE
include pexpect/bashrc.sh, remove old entries

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 recursive-include doc *
 prune doc/_build
 recursive-include examples *
-include README.rst LICENSE
-include setup.py pexpect/bashrc.sh
+include README.rst LICENSE pexpect/bashrc.sh
 recursive-include tests *
 global-exclude __pycache__ *.pyc *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,7 @@
 recursive-include doc *
 prune doc/_build
 recursive-include examples *
-include README LICENSE INSTALL
-include setup.py pexpect.py fdpexpect.py pxssh.py screen.py ANSI.py FSM.py
-include test.env tools/testall.py
+include README.rst LICENSE
+include setup.py pexpect/bashrc.sh
 recursive-include tests *
 global-exclude __pycache__ *.pyc *~


### PR DESCRIPTION
closes issue #280, where using replwrap for bash will likely result in error, because the dependent ``--rcfile=bashrc.sh`` is not found when pexpect is packaged.

Below is a diff to ensure correctness before and after commit:
```
--- /tmp/old	2015-10-06 10:31:28.000000000 -0700
+++ /tmp/new	2015-10-06 10:31:16.000000000 -0700
@@ -44,6 +44,7 @@
 pexpect-4.1.dev/pexpect/__init__.py
 pexpect-4.1.dev/pexpect/ANSI.py
 pexpect-4.1.dev/pexpect/async.py
+pexpect-4.1.dev/pexpect/bashrc.sh
 pexpect-4.1.dev/pexpect/exceptions.py
 pexpect-4.1.dev/pexpect/expect.py
 pexpect-4.1.dev/pexpect/fdpexpect.py
@@ -57,6 +58,7 @@
 pexpect-4.1.dev/pexpect/spawnbase.py
 pexpect-4.1.dev/pexpect/utils.py
 pexpect-4.1.dev/PKG-INFO
+pexpect-4.1.dev/README.rst
 pexpect-4.1.dev/setup.cfg
 pexpect-4.1.dev/setup.py
 pexpect-4.1.dev/tests/
```