### PR TITLE
Asyncio utf8 issue

### DIFF
--- a/pexpect/async.py
+++ b/pexpect/async.py
@@ -41,11 +41,11 @@ class PatternWaiter(asyncio.Protocol):
         spawn._log(s, 'read')
 
         if self.fut.done():
-            spawn.buffer += data
+            spawn.buffer += s
             return
 
         try:
-            index = self.expecter.new_data(data)
+            index = self.expecter.new_data(s)
             if index is not None:
                 # Found a match
                 self.found(index)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -43,9 +43,15 @@ class AsyncTests(PexpectTestCase):
         coro = p.expect('Blah', async=True)
         with self.assertRaises(pexpect.EOF):
             run(coro)
-    
+
     def test_expect_exact(self):
         p = pexpect.spawn('%s list100.py' % sys.executable)
         assert run(p.expect_exact(b'5', async=True)) == 0
         assert run(p.expect_exact(['wpeok', b'11'], async=True)) == 1
         assert run(p.expect_exact([b'foo', pexpect.EOF], async=True)) == 1
+
+    def test_async_utf8(self):
+        p = pexpect.spawn('%s list100.py' % sys.executable, encoding='utf8')
+        assert run(p.expect_exact(u'5', async=True)) == 0
+        assert run(p.expect_exact([u'wpeok', u'11'], async=True)) == 1
+        assert run(p.expect_exact([u'foo', pexpect.EOF], async=True)) == 1


### PR DESCRIPTION
See Issue #286 -- there is a 2nd *new* error on MacOS for the new testcase, but I think it is the same as #213: a TIMEOUT was received instead of expected EOF.