### PR TITLE
Stop asyncio listening to pty once we've found what we need

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 
 install:


### PR DESCRIPTION
Closes gh-213 (fingers crossed)

One symphony and several crazy theories later...

It looks like the problem was the asyncio event loop keeping a reference to the transport, which in turn keeps a reference to the protocol. So after an `expect(... async=True)` call had been made, the transport/protocol set up by that could keep reading events after the expect call had returned. A subsequent `expect(... async=True)` call sets up a new transport/protocol, but it misses events that have already been sent to the previous transport/protocol.

The solution, I hope, is to explicitly detach the transport from the event loop once we've found what we need by calling `transport.pause_reading()`. This makes the tests pass locally on Python 3.4.3.