### PR TITLE
Add new ``delayafterread`` class attribute, for removing Superfluous sleep

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -95,7 +95,6 @@ class Expecter(object):
                     return self.timeout()
                 # Still have time left, so read more data
                 incoming = spawn.read_nonblocking(spawn.maxread, timeout)
-                time.sleep(0.0001)
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:

--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -95,6 +95,8 @@ class Expecter(object):
                     return self.timeout()
                 # Still have time left, so read more data
                 incoming = spawn.read_nonblocking(spawn.maxread, timeout)
+                if self.spawn.delayafterread is not None:
+                    time.sleep(self.spawn.delayafterread)
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:

--- a/pexpect/spawnbase.py
+++ b/pexpect/spawnbase.py
@@ -70,6 +70,10 @@ class SpawnBase(object):
         # Used by terminate() to give kernel time to update process status.
         # Time in seconds.
         self.delayafterterminate = 0.1
+        # After each call to read_nonblocking(), pexpect releases the GIL
+        # through a time.sleep(0.0001) call by default since version 2.1.
+        # When set as value 'None', the old 2.0 behavior is restored.
+        self.delayafterread = 0.0001
         self.softspace = False
         self.name = '<' + repr(self) + '>'
         self.closed = True


### PR DESCRIPTION
Problem
-----------

When mixing pexpect with other I/O intensive applications, the releasing of the GIL periodically though technically incorrect, is helpful to prevent a class of downstream developer bugs.  Such "bugs" are subtle race conditions. 

As an example, test_winsize.py fails without such sleep call because its assisting test subprocess, sigwinch_report.py fails, ``RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>\r\n"`` -- if we look at the code in question, we are in the wrong by performing I/O (print) from within a signal handler.

It is not however obvious at all that this would have anything to do with ``delayaftersleep``, so it is preferable for the project to default to this "safe", but slow behavior.

Relates to #217 #216 #215 #289 

Solution
-----------

We retain existing behavior and provide ``None`` conditional to revert to pexpect 2.0 behavior.

Testing was not done, please request testing by @billpage or @pcpa or any sagemath developer to confirm that this resolves their needs.

References
---------------

http://jessenoller.com/blog/2009/02/01/python-threads-and-the-global-interpreter-lock
https://docs.python.org/2/c-api/init.html#releasing-the-gil-from-extension-code