### PR TITLE
Allow overriding the call to PtyProcess.spawn()

### DIFF
--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -290,7 +290,7 @@ class spawn(SpawnBase):
             self.args = [a if isinstance(a, bytes) else a.encode(self.encoding)
                          for a in self.args]
 
-        self.ptyproc = self.spawnpty(self.args, env=self.env,
+        self.ptyproc = self._spawnpty(self.args, env=self.env,
                                      cwd=self.cwd, **kwargs)
 
         self.pid = self.ptyproc.pid
@@ -300,7 +300,7 @@ class spawn(SpawnBase):
         self.terminated = False
         self.closed = False
 
-    def spawnpty(self, args, **kwargs):
+    def _spawnpty(self, args, **kwargs):
         '''Spawn a pty and return an instance of PtyProcess.'''
         return ptyprocess.PtyProcess.spawn(args, **kwargs)
 

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -290,8 +290,8 @@ class spawn(SpawnBase):
             self.args = [a if isinstance(a, bytes) else a.encode(self.encoding)
                          for a in self.args]
 
-        self.ptyproc = ptyprocess.PtyProcess.spawn(self.args, env=self.env,
-                                                   cwd=self.cwd, **kwargs)
+        self.ptyproc = self.spawnpty(self.args, env=self.env,
+                                     cwd=self.cwd, **kwargs)
 
         self.pid = self.ptyproc.pid
         self.child_fd = self.ptyproc.fd
@@ -299,6 +299,10 @@ class spawn(SpawnBase):
 
         self.terminated = False
         self.closed = False
+
+    def spawnpty(self, args, **kwargs):
+        '''Spawn a pty and return an instance of PtyProcess.'''
+        return ptyprocess.PtyProcess.spawn(args, **kwargs)
 
     def close(self, force=True):
         '''This closes the connection with the child application. Note that


### PR DESCRIPTION
For use in SageMath, it is useful to be able to override some methods of the `PtyProcess` class. For this, we need to be able to customize the call `PtyProcess.spawn()` in pexpect.