### PR TITLE
Bugfix: AttributeError: 'spawn' object has no attribute 'ptyproc'

### DIFF
--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -210,7 +210,8 @@ class spawn(SpawnBase):
         s.append('match: %r' % (self.match,))
         s.append('match_index: ' + str(self.match_index))
         s.append('exitstatus: ' + str(self.exitstatus))
-        s.append('flag_eof: ' + str(self.flag_eof))
+        if hasattr(self, 'ptyproc'):
+            s.append('flag_eof: ' + str(self.flag_eof))
         s.append('pid: ' + str(self.pid))
         s.append('child_fd: ' + str(self.child_fd))
         s.append('closed: ' + str(self.closed))

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -28,7 +28,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
         """ Exercise derived spawn.__str__() """
         # given,
         child = pexpect.spawn(None, None)
-        child.closed = False
+        child.read_nonblocking = lambda size, timeout: b''
         try:
             child.expect('alpha', timeout=0.1)
         except pexpect.TIMEOUT:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -31,7 +31,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
         child.read_nonblocking = lambda size, timeout: b''
         try:
             child.expect('alpha', timeout=0.1)
-        except pexpect.TIMEOUT:
-            pass
+        except pexpect.TIMEOUT as e:
+            str(e)  # Smoketest
         else:
-            assert False, 'TIMEOUT exception expected. No exception aised.'
+            assert False, 'TIMEOUT exception expected. No exception raised.'

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -24,3 +24,14 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
         # verify
         assert isinstance(value, str)
 
+    def test_str_before_spawn(self):
+        """ Exercise derived spawn.__str__() """
+        # given,
+        child = pexpect.spawn(None, None)
+        child.closed = False
+        try:
+            child.expect('alpha', timeout=0.1)
+        except pexpect.TIMEOUT:
+            pass
+        else:
+            assert False, 'TIMEOUT exception expected. No exception aised.'


### PR DESCRIPTION
When subclassing ``spawn()``, or otherwise using ``command=None`` argument as in the given test, ``self.ptyproc`` is left unassigned resulting in exception, ``AttributeError: 'spawn' object has no attribute 'jptyproc'`` instead of ``TIMEOUT``.

Solution is to wrap access of this variable by ``hasattr``. Closes #298
