### PR TITLE
Add new ``delayafterread`` class attribute, for removing Superfluous sleep

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -95,7 +95,8 @@ class Expecter(object):
                     return self.timeout()
                 # Still have time left, so read more data
                 incoming = spawn.read_nonblocking(spawn.maxread, timeout)
-                time.sleep(0.0001)
+                if self.spawn.delayafterread is not None:
+                    time.sleep(self.spawn.delayafterread)
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:

--- a/pexpect/spawnbase.py
+++ b/pexpect/spawnbase.py
@@ -62,7 +62,7 @@ class SpawnBase(object):
         # Data before searchwindowsize point is preserved, but not searched.
         self.searchwindowsize = searchwindowsize
         # Delay used before sending data to child. Time in seconds.
-        # Most Linux machines don't like this to be below 0.03 (30 ms).
+        # Set this to None to skip the time.sleep() call completely.
         self.delaybeforesend = 0.05
         # Used by close() to give kernel time to update process status.
         # Time in seconds.
@@ -70,9 +70,11 @@ class SpawnBase(object):
         # Used by terminate() to give kernel time to update process status.
         # Time in seconds.
         self.delayafterterminate = 0.1
-        # After each call to read_nonblocking(), pexpect releases the GIL
-        # through a time.sleep(0.0001) call by default since version 2.1.
-        # When set as value 'None', the old 2.0 behavior is restored.
+        # Delay in seconds to sleep after each call to read_nonblocking().
+        # Set this to None to skip the time.sleep() call completely: that
+        # would restore the behavior from pexpect-2.0 (for performance
+        # reasons or because you don't want to release Python's global
+        # interpreter lock).
         self.delayafterread = 0.0001
         self.softspace = False
         self.name = '<' + repr(self) + '>'

--- a/pexpect/spawnbase.py
+++ b/pexpect/spawnbase.py
@@ -70,6 +70,10 @@ class SpawnBase(object):
         # Used by terminate() to give kernel time to update process status.
         # Time in seconds.
         self.delayafterterminate = 0.1
+        # After each call to read_nonblocking(), pexpect releases the GIL
+        # through a time.sleep(0.0001) call by default since version 2.1.
+        # When set as value 'None', the old 2.0 behavior is restored.
+        self.delayafterread = 0.0001
         self.softspace = False
         self.name = '<' + repr(self) + '>'
         self.closed = True

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -25,3 +25,21 @@ class TestCaseDelay(PexpectTestCase.PexpectTestCase):
         p.delaybeforesend = None
         p.sendline("line 3")
         p.expect("line 3")
+
+    def test_delayafterread(self):
+        """
+        Test various values for delayafterread.
+        """
+        p = pexpect.spawn("cat")
+
+        p.delayafterread = 1
+        p.sendline("line 1")
+        p.expect("line 1")
+
+        p.delayafterread = 0.0
+        p.sendline("line 2")
+        p.expect("line 2")
+
+        p.delayafterread = None
+        p.sendline("line 3")
+        p.expect("line 3")

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -433,7 +433,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         self._before_after(p)
 
     def _ordering(self, p):
-        p.timeout = 5
+        p.timeout = 20
         p.expect(b'>>> ')
 
         p.sendline('list(range(4*3))')


### PR DESCRIPTION
The many calls to `time.sleep(0.0001)` in pexpect cause a serious performance loss when using pexpect in SageMath: that sleep was the main reason that SageMath was using pexpect-2.0 for a long time, see #215. And it seems that the releasing of the GIL during this sleep can also problematic, see #291.

To solve this problem, we make the sleep optional with a new `delayafterread` class attribute: if set to `None`, the sleep will be skipped completely (which is not the same as calling `time.sleep(0)`).