### PR TITLE
Display current searcher in error messages

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -44,6 +44,7 @@ class Expecter(object):
             spawn.match = None
             spawn.match_index = None
             msg = str(spawn)
+            msg += '\nsearcher: %s' % self.searcher
             if err is not None:
                 msg = str(err) + '\n' + msg
             raise EOF(msg)
@@ -63,6 +64,7 @@ class Expecter(object):
             spawn.match = None
             spawn.match_index = None
             msg = str(spawn)
+            msg += '\nsearcher: %s' % self.searcher
             if err is not None:
                 msg = str(err) + '\n' + msg
             raise TIMEOUT(msg)

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -205,7 +205,6 @@ class spawn(SpawnBase):
         s.append(repr(self))
         s.append('command: ' + str(self.command))
         s.append('args: %r' % (self.args,))
-        s.append('searcher: %r' % (self.searcher,))
         s.append('buffer (last 100 chars): %r' % (
                 self.buffer[-100:] if self.buffer else self.buffer,))
         s.append('before (last 100 chars): %r' % (


### PR DESCRIPTION
Without attaching it to the spawn object

Closes gh-345