### PR TITLE
Raise proper exception when connection cannot be established

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -277,7 +277,7 @@ class pxssh (spawn):
         # This does not distinguish between a remote server 'password' prompt
         # and a local ssh 'passphrase' prompt (for unlocking a private key).
         spawn._spawn(self, cmd)
-        i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT, "(?i)connection closed by remote host"], timeout=login_timeout)
+        i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT, "(?i)connection closed by remote host", EOF], timeout=login_timeout)
 
         # First phase
         if i==0:
@@ -292,6 +292,9 @@ class pxssh (spawn):
         if i==4:
             self.sendline(terminal_type)
             i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+        if i==7:
+            self.close()
+            raise ExceptionPxssh('Could not establish connection to host')
 
         # Second phase
         if i==0:

--- a/tests/fakessh/ssh
+++ b/tests/fakessh/ssh
@@ -7,6 +7,11 @@ PY3 = (sys.version_info[0] >= 3)
 if not PY3:
     input = raw_input
 
+server = sys.argv[-1]
+if server == 'noserver':
+    print('No route to host')
+    sys.exit(1)
+
 print("Mock SSH client for tests. Do not enter real security info.")
 
 pw = getpass.getpass('password:')

--- a/tests/test_pxssh.py
+++ b/tests/test_pxssh.py
@@ -48,6 +48,15 @@ class PxsshTestCase(SSHTestBase):
         else:
             assert False, 'should have raised exception, pxssh.ExceptionPxssh'
 
+    def test_connection_refused(self):
+        ssh = pxssh.pxssh()
+        try:
+            ssh.login('noserver', 'me', password='s3cret')
+        except pxssh.ExceptionPxssh:
+            pass
+        else:
+            assert False, 'should have raised exception, pxssh.ExceptionPxssh'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will cover the cases of connection refused, no route to host, and maybe some more. 

Currently the error is a bit hard to understand: 

```
Traceback (most recent call last):
  File "/home/per/.homeassistant/deps/pexpect/spawnbase.py", line 144, in read_nonblocking
    s = os.read(self.child_fd, size)
OSError: [Errno 5] Input/output error

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/per/.homeassistant/deps/pexpect/expect.py", line 97, in expect_loop
    incoming = spawn.read_nonblocking(spawn.maxread, timeout)
  File "/home/per/.homeassistant/deps/pexpect/pty_spawn.py", line 455, in read_nonblocking
    return super(spawn, self).read_nonblocking(size)
  File "/home/per/.homeassistant/deps/pexpect/spawnbase.py", line 149, in read_nonblocking
    raise EOF('End Of File (EOF). Exception style platform.')
pexpect.exceptions.EOF: End Of File (EOF). Exception style platform.
```

this will be replaced by the following:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/per/pexpect/pexpect/pxssh.py", line 297, in login
    raise ExceptionPxssh('Could not establish connection to host')
pexpect.pxssh.ExceptionPxssh: Could not establish connection to host
```