### PR TITLE
Restore POSIX support to fdpexpect

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -9,6 +9,7 @@ API documentation
    popen_spawn
    replwrap
    pxssh
+   socket_pexpect
 
 The modules ``pexpect.screen`` and ``pexpect.ANSI`` have been deprecated in
 Pexpect version 4. They were separate from the main use cases for Pexpect, and

--- a/doc/api/socket_pexpect.rst
+++ b/doc/api/socket_pexpect.rst
@@ -1,0 +1,16 @@
+socket_pexpect - use pexpect with a socket
+==========================================
+
+.. automodule:: pexpect.socket_pexpect
+
+socket_pexpect class
+--------------------
+
+.. autoclass:: socket_spawn
+   :show-inheritance:
+
+   .. method:: expect
+               expect_exact
+               expect_list
+
+      As :class:`pexpect.spawn`.

--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -23,6 +23,7 @@ PEXPECT LICENSE
 
 from .spawnbase import SpawnBase
 from .exceptions import ExceptionPexpect
+from .pty_spawn import spawn
 import os
 
 __all__ = ['fdspawn']
@@ -112,3 +113,9 @@ class fdspawn(SpawnBase):
         "Call self.write() for each item in sequence"
         for s in sequence:
             self.write(s)
+
+    def read_nonblocking(self, size=1, timeout=-1):
+        if os.name == 'posix':
+            spawn.read_nonblocking(self, size, timeout)
+        else:
+            SpawnBase.read_nonblocking(self, size, timeout)

--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -116,6 +116,8 @@ class fdspawn(SpawnBase):
 
     def read_nonblocking(self, size=1, timeout=-1):
         if os.name == 'posix':
+            self.__class__ = spawn
             spawn.read_nonblocking(self, size, timeout)
+            self.__class__ = SpawnBase
         else:
             SpawnBase.read_nonblocking(self, size, timeout)

--- a/pexpect/socket_pexpect.py
+++ b/pexpect/socket_pexpect.py
@@ -1,4 +1,4 @@
-'''This is like fdpexpect, but it will work sockets. You are responsible
+'''This is like fdpexpect, but it will work with sockets. You are responsible
 for opening and closing the socket.
 
 PEXPECT LICENSE

--- a/pexpect/socket_pexpect.py
+++ b/pexpect/socket_pexpect.py
@@ -70,7 +70,7 @@ class socket_spawn(fdspawn):
                     if timeout is not None:
                         timeout = end_time - time.time()
                         if timeout < 0:
-                            return tuple([], [], [])
+                            return [], [], []
                 else:
                     # something else caused the select.error, so
                     # this actually is an exception.

--- a/pexpect/socket_pexpect.py
+++ b/pexpect/socket_pexpect.py
@@ -1,0 +1,77 @@
+'''This is like fdpexpect, but it will work sockets. You are responsible
+for opening and closing the socket.
+
+PEXPECT LICENSE
+
+    This license is approved by the OSI and FSF as GPL-compatible.
+        http://opensource.org/licenses/isc-license.txt
+
+    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
+    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
+    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+'''
+
+import errno
+import select
+import sys
+import time
+
+from .fdpexpect import fdspawn
+from .exceptions import TIMEOUT
+
+__all__ = ['socket_pexpect']
+
+
+class socket_spawn(fdspawn):
+    '''This is like pexpect.fdspawn but it works with sockets.'''
+
+    def read_nonblocking(self, size=1, timeout=-1):
+        '''The read_nonblocking method of fdspawn assumes that the file
+        will never block. This is not the case for sockets. So we use
+        select to implement the timeout.'''
+        if timeout == -1:
+            timeout = self.timeout
+        rlist = [self.child_fd]
+        wlist = []
+        xlist = []
+        rlist, wlist, xlist = self.__select(rlist, wlist, xlist, timeout)
+        if self.child_fd not in rlist:
+            raise TIMEOUT('Timeout exceeded.')
+        return super(fdspawn, self).read_nonblocking(size)
+
+    def __select(self, iwtd, owtd, ewtd, timeout=None):
+
+        '''This is a wrapper around select.select() that ignores signals. If
+        select.select raises a select.error exception and errno is an EINTR
+        error then it is ignored. Mainly this is used to ignore sigwinch
+        (terminal resize). '''
+
+        # if select() is interrupted by a signal (errno==EINTR) then
+        # we loop back and enter the select() again.
+        if timeout is not None:
+            end_time = time.time() + timeout
+        while True:
+            try:
+                return select.select(iwtd, owtd, ewtd, timeout)
+            except select.error:
+                err = sys.exc_info()[1]
+                if err.args[0] == errno.EINTR:
+                    # if we loop back we have to subtract the
+                    # amount of time we already waited.
+                    if timeout is not None:
+                        timeout = end_time - time.time()
+                        if timeout < 0:
+                            return tuple([], [], [])
+                else:
+                    # something else caused the select.error, so
+                    # this actually is an exception.
+                    raise

--- a/pexpect/utils.py
+++ b/pexpect/utils.py
@@ -1,6 +1,9 @@
 import os
 import sys
 import stat
+import select
+import errno
+import time
 
 
 def is_executable_file(path):
@@ -110,3 +113,32 @@ def split_command_line(command_line):
     if arg != '':
         arg_list.append(arg)
     return arg_list
+
+
+def select_ignore_interrupts(iwtd, owtd, ewtd, timeout=None):
+
+    '''This is a wrapper around select.select() that ignores signals. If
+    select.select raises a select.error exception and errno is an EINTR
+    error then it is ignored. Mainly this is used to ignore sigwinch
+    (terminal resize). '''
+
+    # if select() is interrupted by a signal (errno==EINTR) then
+    # we loop back and enter the select() again.
+    if timeout is not None:
+        end_time = time.time() + timeout
+    while True:
+        try:
+            return select.select(iwtd, owtd, ewtd, timeout)
+        except select.error:
+            err = sys.exc_info()[1]
+            if err.args[0] == errno.EINTR:
+                # if we loop back we have to subtract the
+                # amount of time we already waited.
+                if timeout is not None:
+                    timeout = end_time - time.time()
+                    if timeout < 0:
+                        return([], [], [])
+            else:
+                # something else caused the select.error, so
+                # this actually is an exception.
+                raise

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+'''
+PEXPECT LICENSE
+
+    This license is approved by the OSI and FSF as GPL-compatible.
+        http://opensource.org/licenses/isc-license.txt
+
+    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
+    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
+    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+'''
+import pexpect
+from pexpect import socket_pexpect
+import unittest
+# from . import PexpectTestCase
+import PexpectTestCase
+import os
+import socket
+import sys
+
+class ExpectTestCase(PexpectTestCase.PexpectTestCase):
+    def setUp(self):
+        print(self.id())
+        PexpectTestCase.PexpectTestCase.setUp(self)
+
+    def test_socket (self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
+        session.expect('Press Return to continue:')
+        motd = """\
+------------------------------------------------------------------------------
+*               Welcome to THE WEATHER UNDERGROUND telnet service!            *
+------------------------------------------------------------------------------
+*                                                                            *
+*   National Weather Service information provided by Alden Electronics, Inc. *
+*    and updated each minute as reports come in over our data feed.          *
+*                                                                            *
+*   **Note: If you cannot get past this opening screen, you must use a       *
+*   different version of the "telnet" program--some of the ones for IBM      *
+*   compatible PC's have a bug that prevents proper connection.              *
+*                                                                            *
+*           comments: jmasters@wunderground.com                              *
+------------------------------------------------------------------------------
+""".replace('\n', '\n\r') + "\r\n"
+        self.assertEqual(session.before, motd)
+
+    def test_timeout(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
+        result_list = ['Bogus response', pexpect.TIMEOUT]
+        result = session.expect(result_list)
+        self.assertEqual(result, result_list.index(pexpect.TIMEOUT))
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(ExpectTestCase, 'test')

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -101,6 +101,7 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
             os.kill(test_proc.pid, signal.SIGINT)
             if not test_proc.is_alive():
                 break
+        test_proc.join()
 
     def test_maxread(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -50,7 +50,7 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 *                                                                            *
 *           comments: jmasters@wunderground.com                              *
 ------------------------------------------------------------------------------
-""".replace('\n', '\n\r') + b"\r\n"
+""".replace(b'\n', b'\n\r') + b"\r\n"
         self.assertEqual(session.before, motd)
 
     def test_timeout(self):

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -63,6 +63,14 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         session.expect(pexpect.EOF)
         self.assertEqual(session.before, b'')
 
+    def test_not_int(self):
+        with self.assertRaises(pexpect.ExceptionPexpect):
+            session = socket_pexpect.socket_spawn('bogus', timeout=10)
+
+    def test_not_file_descriptor(self):
+        with self.assertRaises(pexpect.ExceptionPexpect):
+            session = socket_pexpect.socket_spawn(-1, timeout=10)
+
     def test_timeout(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(('rainmaker.wunderground.com', 23))

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -36,7 +36,7 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         sock.connect(('rainmaker.wunderground.com', 23))
         session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
         session.expect('Press Return to continue:')
-        motd = """\
+        motd = b"""\
 ------------------------------------------------------------------------------
 *               Welcome to THE WEATHER UNDERGROUND telnet service!            *
 ------------------------------------------------------------------------------
@@ -50,14 +50,14 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 *                                                                            *
 *           comments: jmasters@wunderground.com                              *
 ------------------------------------------------------------------------------
-""".replace('\n', '\n\r') + "\r\n"
+""".replace('\n', '\n\r') + b"\r\n"
         self.assertEqual(session.before, motd)
 
     def test_timeout(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(('rainmaker.wunderground.com', 23))
         session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
-        result_list = ['Bogus response', pexpect.TIMEOUT]
+        result_list = [b'Bogus response', pexpect.TIMEOUT]
         result = session.expect(result_list)
         self.assertEqual(result, result_list.index(pexpect.TIMEOUT))
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -22,9 +22,12 @@ import pexpect
 from pexpect import socket_pexpect
 import unittest
 from . import PexpectTestCase
+import multiprocessing
 import os
+import signal
 import socket
-import sys
+import time
+
 
 class ExpectTestCase(PexpectTestCase.PexpectTestCase):
     def setUp(self):
@@ -46,7 +49,7 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 ------------------------------------------------------------------------------
 """.replace(b'\n', b'\n\r') + b"\r\n"
 
-    def test_socket (self):
+    def test_socket(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(('rainmaker.wunderground.com', 23))
         session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
@@ -67,6 +70,29 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         result_list = [b'Bogus response', pexpect.TIMEOUT]
         result = session.expect(result_list)
         self.assertEqual(result, result_list.index(pexpect.TIMEOUT))
+
+    def test_interrupt(self):
+        def socket_fn(self):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('rainmaker.wunderground.com', 23))
+            session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
+            session.expect('Press Return to continue:')
+            self.assertEqual(session.before, self.motd)
+            session.send('\r\n')
+            session.expect('or enter 3 letter forecast city code--')
+            session.send('\r\n')
+            session.expect('Selection:')
+            session.send('X\r\n')
+            session.expect(pexpect.EOF)
+            self.assertEqual(session.before, b'')
+        test_proc = multiprocessing.Process(target=socket_fn, args=(self,))
+        test_proc.daemon = True
+        test_proc.start()
+        while True:
+            time.sleep(0.250)
+            os.kill(test_proc.pid, signal.SIGINT)
+            if not test_proc.is_alive():
+                break
 
     def test_maxread(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -52,6 +52,13 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
         session.expect('Press Return to continue:')
         self.assertEqual(session.before, self.motd)
+        session.send('\r\n')
+        session.expect('or enter 3 letter forecast city code--')
+        session.send('\r\n')
+        session.expect('Selection:')
+        session.send('X\r\n')
+        session.expect(pexpect.EOF)
+        self.assertEqual(session.before, b'')
 
     def test_timeout(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -68,6 +75,13 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         session.maxread = 1100
         session.expect('Press Return to continue:')
         self.assertEqual(session.before, self.motd)
+        session.send('\r\n')
+        session.expect('or enter 3 letter forecast city code--')
+        session.send('\r\n')
+        session.expect('Selection:')
+        session.send('X\r\n')
+        session.expect(pexpect.EOF)
+        self.assertEqual(session.before, b'')
 
     def test_fd_isalive (self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -21,8 +21,7 @@ PEXPECT LICENSE
 import pexpect
 from pexpect import socket_pexpect
 import unittest
-# from . import PexpectTestCase
-import PexpectTestCase
+from . import PexpectTestCase
 import os
 import socket
 import sys

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -77,6 +77,13 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         sock.close()
         assert not session.isalive(), "Should not be alive after close()"
 
+    def test_fd_isatty (self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = socket_pexpect.socket_spawn(sock.fileno(), timeout=10)
+        assert not session.isatty()
+        session.close()
+
     def test_fileobj(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(('rainmaker.wunderground.com', 23))


### PR DESCRIPTION
Minimal changes to restore POSIX support to [fdpexpect](http://pexpect.readthedocs.io/en/stable/api/fdpexpect.html).