### PR TITLE
Restore POSIX support to fdpexpect.

### DIFF
--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -115,10 +115,18 @@ class fdspawn(SpawnBase):
             self.write(s)
 
     def read_nonblocking(self, size=1, timeout=-1):
-        """The read_nonblocking method of SpawnBase assumes that a call to
+        """ Read from the file descriptor and return the result as a string.
+
+        The read_nonblocking method of SpawnBase assumes that a call to
         os.read will not block. This is not the case for POSIX file like
         objects like sockets and serial ports. So we use select to implement
-        the timeout on POSIX."""
+        the timeout on POSIX.
+
+        :param size:    Read at most size bytes
+        :param timeout: Wait timeout seconds for file descriptor to be ready
+                        to read. If -1, use self.timeout. If 0, poll.
+        :return:        String containing the bytes read
+        """
         if os.name == 'posix':
             if timeout == -1:
                 timeout = self.timeout

--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -115,10 +115,10 @@ class fdspawn(SpawnBase):
             self.write(s)
 
     def read_nonblocking(self, size=1, timeout=-1):
-        '''The read_nonblocking method of fdspawn assumes that the file
-        will never block. This is not the case for all file like objects
-        that support fileno (e.g. POSIX sockets and serial ports). So we
-        use select to implement the timeout on POSIX.'''
+        """The read_nonblocking method of SpawnBase assumes that a call to
+        os.read will not block. This is not the case for POSIX file like
+        objects like sockets and serial ports. So we use select to implement
+        the timeout on POSIX."""
         if os.name == 'posix':
             if timeout == -1:
                 timeout = self.timeout

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -403,8 +403,6 @@ class spawn(SpawnBase):
         '''
         return self.ptyproc.setecho(state)
 
-        self.echo = state
-
     def read_nonblocking(self, size=1, timeout=-1):
         '''This reads at most size characters from the child application. It
         includes a timeout. If the read does not complete within the timeout

--- a/pexpect/utils.py
+++ b/pexpect/utils.py
@@ -1,6 +1,9 @@
 import os
 import sys
 import stat
+import select
+import time
+import errno
 
 
 def is_executable_file(path):
@@ -110,3 +113,32 @@ def split_command_line(command_line):
     if arg != '':
         arg_list.append(arg)
     return arg_list
+
+
+def select_ignore_interrupts(iwtd, owtd, ewtd, timeout=None):
+
+    '''This is a wrapper around select.select() that ignores signals. If
+    select.select raises a select.error exception and errno is an EINTR
+    error then it is ignored. Mainly this is used to ignore sigwinch
+    (terminal resize). '''
+
+    # if select() is interrupted by a signal (errno==EINTR) then
+    # we loop back and enter the select() again.
+    if timeout is not None:
+        end_time = time.time() + timeout
+    while True:
+        try:
+            return select.select(iwtd, owtd, ewtd, timeout)
+        except select.error:
+            err = sys.exc_info()[1]
+            if err.args[0] == errno.EINTR:
+                # if we loop back we have to subtract the
+                # amount of time we already waited.
+                if timeout is not None:
+                    timeout = end_time - time.time()
+                    if timeout < 0:
+                        return([], [], [])
+            else:
+                # something else caused the select.error, so
+                # this actually is an exception.
+                raise

--- a/pexpect/utils.py
+++ b/pexpect/utils.py
@@ -5,6 +5,12 @@ import select
 import time
 import errno
 
+try:
+    InterruptedError
+except NameError:
+    # Alias Python2 exception to Python3
+    InterruptedError = select.error
+
 
 def is_executable_file(path):
     """Checks that path is an executable regular file, or a symlink towards one.
@@ -129,7 +135,7 @@ def select_ignore_interrupts(iwtd, owtd, ewtd, timeout=None):
     while True:
         try:
             return select.select(iwtd, owtd, ewtd, timeout)
-        except select.error:
+        except InterruptedError:
             err = sys.exc_info()[1]
             if err.args[0] == errno.EINTR:
                 # if we loop back we have to subtract the

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -153,6 +153,20 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         session.expect(pexpect.EOF)
         self.assertEqual(session.before, b'')
 
+    def test_socket_with_write(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((self.host, self.port))
+        session = fdpexpect.fdspawn(sock.fileno(), timeout=10)
+        session.expect(self.prompt1)
+        self.assertEqual(session.before, self.motd)
+        session.write(self.enter)
+        session.expect(self.prompt2)
+        session.write(self.enter)
+        session.expect(self.prompt3)
+        session.write(self.exit)
+        session.expect(pexpect.EOF)
+        self.assertEqual(session.before, b'')
+
     def test_not_int(self):
         with self.assertRaises(pexpect.ExceptionPexpect):
             session = fdpexpect.fdspawn('bogus', timeout=10)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -207,7 +207,7 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
         session.expect(self.prompt2)
         session.send(self.enter)
         session.expect(self.prompt3)
-        session.send(self.enter)
+        session.send(self.exit)
         session.expect(pexpect.EOF)
         self.assertEqual(session.before, b'')
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+'''
+PEXPECT LICENSE
+
+    This license is approved by the OSI and FSF as GPL-compatible.
+        http://opensource.org/licenses/isc-license.txt
+
+    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
+    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
+    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+'''
+import pexpect
+from pexpect import fdpexpect
+import unittest
+from . import PexpectTestCase
+import multiprocessing
+import os
+import signal
+import socket
+import time
+
+
+class ExpectTestCase(PexpectTestCase.PexpectTestCase):
+    def setUp(self):
+        print(self.id())
+        PexpectTestCase.PexpectTestCase.setUp(self)
+        self.motd = b"""\
+------------------------------------------------------------------------------
+*               Welcome to THE WEATHER UNDERGROUND telnet service!            *
+------------------------------------------------------------------------------
+*                                                                            *
+*   National Weather Service information provided by Alden Electronics, Inc. *
+*    and updated each minute as reports come in over our data feed.          *
+*                                                                            *
+*   **Note: If you cannot get past this opening screen, you must use a       *
+*   different version of the "telnet" program--some of the ones for IBM      *
+*   compatible PC's have a bug that prevents proper connection.              *
+*                                                                            *
+*           comments: jmasters@wunderground.com                              *
+------------------------------------------------------------------------------
+""".replace(b'\n', b'\n\r') + b"\r\n"
+
+    def test_socket(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = fdpexpect.fdspawn(sock.fileno(), timeout=10)
+        session.expect('Press Return to continue:')
+        self.assertEqual(session.before, self.motd)
+        session.send('\r\n')
+        session.expect('or enter 3 letter forecast city code--')
+        session.send('\r\n')
+        session.expect('Selection:')
+        session.send('X\r\n')
+        session.expect(pexpect.EOF)
+        self.assertEqual(session.before, b'')
+
+    def test_not_int(self):
+        with self.assertRaises(pexpect.ExceptionPexpect):
+            session = fdpexpect.fdspawn('bogus', timeout=10)
+
+    def test_not_file_descriptor(self):
+        with self.assertRaises(pexpect.ExceptionPexpect):
+            session = fdpexpect.fdspawn(-1, timeout=10)
+
+    def test_timeout(self):
+        with self.assertRaises(pexpect.TIMEOUT):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('rainmaker.wunderground.com', 23))
+            session = fdpexpect.fdspawn(sock, timeout=10)
+            session.expect(b'Bogus response')
+
+    def test_interrupt(self):
+        def socket_fn(self):
+            result = 0
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.connect(('rainmaker.wunderground.com', 23))
+                session = fdpexpect.fdspawn(sock, timeout=10)
+                # Get all data from server
+                session.read_nonblocking(size=4096)
+                # This read should timeout
+                session.read_nonblocking(size=4096)
+            except pexpect.TIMEOUT:
+                result = 1
+            exit(result)
+        test_proc = multiprocessing.Process(target=socket_fn, args=(self,))
+        test_proc.daemon = True
+        test_proc.start()
+        time.sleep(5.0)
+        while True:
+            if test_proc.is_alive():
+                os.kill(test_proc.pid, signal.SIGWINCH)
+            else:
+                break
+            time.sleep(0.250)
+        test_proc.join()
+        self.assertEqual(test_proc.exitcode, 1)
+
+    def test_maxread(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = fdpexpect.fdspawn(sock.fileno(), timeout=10)
+        session.maxread = 1100
+        session.expect('Press Return to continue:')
+        self.assertEqual(session.before, self.motd)
+        session.send('\r\n')
+        session.expect('or enter 3 letter forecast city code--')
+        session.send('\r\n')
+        session.expect('Selection:')
+        session.send('X\r\n')
+        session.expect(pexpect.EOF)
+        self.assertEqual(session.before, b'')
+
+    def test_fd_isalive (self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = fdpexpect.fdspawn(sock.fileno(), timeout=10)
+        assert session.isalive()
+        sock.close()
+        assert not session.isalive(), "Should not be alive after close()"
+
+    def test_fd_isatty (self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = fdpexpect.fdspawn(sock.fileno(), timeout=10)
+        assert not session.isatty()
+        session.close()
+
+    def test_fileobj(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('rainmaker.wunderground.com', 23))
+        session = fdpexpect.fdspawn(sock, timeout=10) # Should get the fileno from the socket
+        session.expect('Press Return to continue:')
+        session.close()
+        assert not session.isalive()
+        session.close()  # Smoketest - should be able to call this again
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(ExpectTestCase, 'test')


### PR DESCRIPTION
Factor out uninterruptible select and put the code in utils as `select_ignore_interrupts`. Modify `fdpexpect` to use `select_ignore_interrupts` if `os.name` is `posix`. This should restore POSIX support without affecting Windows support.