### PR TITLE
format license according to the standard template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-PEXPECT LICENSE
+ISC LICENSE
 
     This license is approved by the OSI and FSF as GPL-compatible.
         http://opensource.org/licenses/isc-license.txt
@@ -6,9 +6,10 @@ PEXPECT LICENSE
     Copyright (c) 2013-2014, Pexpect development team
     Copyright (c) 2012, Noah Spurrier <noah@noah.org>
 
-    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
-    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
-    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    
     THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
     WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
     MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR


### PR DESCRIPTION
Having "PEXPECT LICENSE" at the top of the file makes it seem like it is a custom license with specific terms, rather than the license of the Pexpect project. The text corresponds (as the header note righfully indicates) to the ISC License, so this change edits the header to hopefully clarify this.

Additionally, the formatting was slightly different from the standard ISC license template (as seen on https://opensource.org/licenses/isc-license or http://choosealicense.com/licenses/isc/), so the first paragraph was converted to regular sentence case rather than ALL CAPS like the disclaimer.