### PR TITLE
Prepare 4.2 release

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -11,7 +11,10 @@ Version 4.2
   :class:`~.run` family of calls containing a value for ``PATH``, its value is
   used to discover the target executable from a relative path, rather than the
   current process's environment ``PATH``.  This mirrors the behavior of
-  :func:`subprocess.Popen` in the standard library.
+  :func:`subprocess.Popen` in the standard library (:ghissue:`348`).
+
+* Regression: Re-introduce capability for :meth:`read_nonblocking` in class
+  :class:`fdspawn` as previously supported in version 3.3 (:ghissue:`359`).
 
 Version 4.0
 ```````````

--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -115,17 +115,20 @@ class fdspawn(SpawnBase):
             self.write(s)
 
     def read_nonblocking(self, size=1, timeout=-1):
-        """ Read from the file descriptor and return the result as a string.
+        """
+        Read from the file descriptor and return the result as a string.
 
-        The read_nonblocking method of SpawnBase assumes that a call to
-        os.read will not block. This is not the case for POSIX file like
-        objects like sockets and serial ports. So we use select to implement
-        the timeout on POSIX.
+        The read_nonblocking method of :class:`SpawnBase` assumes that a call
+        to os.read will not block (timeout parameter is ignored). This is not
+        the case for POSIX file-like objects such as sockets and serial ports.
 
-        :param size:    Read at most size bytes
-        :param timeout: Wait timeout seconds for file descriptor to be ready
-                        to read. If -1, use self.timeout. If 0, poll.
-        :return:        String containing the bytes read
+        Use :func:`select.select`, timeout is implemented conditionally for
+        POSIX systems.
+
+        :param int size: Read at most *size* bytes.
+        :param int timeout: Wait timeout seconds for file descriptor to be
+            ready to read. When -1 (default), use self.timeout. When 0, poll.
+        :return: String containing the bytes read
         """
         if os.name == 'posix':
             if timeout == -1:


### PR DESCRIPTION
- bump version in documentation via pexpect/__init__.py
- describe PR #359 in changelog as regression
- minor docstring enhancements to fdspawn.read_nonblocking()