### PR TITLE
Fix running 'env' in replwrap-ed bash

### DIFF
--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -109,5 +109,14 @@ def bash(command="bash"):
     bashrc = os.path.join(os.path.dirname(__file__), 'bashrc.sh')
     child = pexpect.spawn(command, ['--rcfile', bashrc], echo=False,
                           encoding='utf-8')
-    return REPLWrapper(child, u'\$', u"PS1='{0}' PS2='{1}' PROMPT_COMMAND=''",
+
+    # If the user runs 'env', the value of PS1 will be in the output. To avoid
+    # replwrap seeing that as the next prompt, we'll embed the marker characters
+    # for invisible characters in the prompt; these show up when inspecting the
+    # environment variable, but not when bash displays the prompt.
+    ps1 = PEXPECT_PROMPT[:5] + u'\[\]' + PEXPECT_PROMPT[5:]
+    ps2 = PEXPECT_CONTINUATION_PROMPT[:5] + u'\[\]' + PEXPECT_CONTINUATION_PROMPT[5:]
+    prompt_change = u"PS1='{0}' PS2='{1}' PROMPT_COMMAND=''".format(ps1, ps2)
+
+    return REPLWrapper(child, u'\$', prompt_change,
                        extra_init_cmd="export PAGER=cat")

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -33,6 +33,13 @@ class REPLWrapTestCase(unittest.TestCase):
         res = bash.run_command('man sleep', timeout=5)
         assert 'SLEEP' in res, res
 
+    def test_bash_env(self):
+        bash = replwrap.bash()
+        res = bash.run_command("env")
+        self.assertIn('PS1', res)
+        res = bash.run_command("echo $HOME")
+        assert res.startswith('/'), res
+
     def test_long_running_multiline(self):
         " ensure the default timeout is used for multi-line commands. "
         bash = replwrap.bash()

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -34,6 +34,8 @@ class REPLWrapTestCase(unittest.TestCase):
         assert 'SLEEP' in res, res
 
     def test_bash_env(self):
+        """env, which displays PS1=..., should not mess up finding the prompt.
+        """
         bash = replwrap.bash()
         res = bash.run_command("env")
         self.assertIn('PS1', res)


### PR DESCRIPTION
From takluyver/bash_kernel#33 - if you run `env` or `echo $PS1` inside a replwrap bash, the output will contain the prompt string. Pexpect will think that is the prompt, cut off the output there, and then get into a confused state about the output of future commands.

This avoids that by inserting some characters `\[\]` which are displayed when inspecting the environment variable, but invisible when bash actually renders the prompt. This means that the output of `env` or `echo $PS1` doesn't match the prompt replwrap is looking for.

Those characters are intended to mark a set of non-printing characters (e.g. to change the terminal colour), so having them together as a pair should have no ill effects. I've verified in interactive testing that it works.