### PR TITLE
dont remove reference to _UnixReadPipeTransport

### DIFF
--- a/pexpect/async.py
+++ b/pexpect/async.py
@@ -12,22 +12,30 @@ def expect_async(expecter, timeout=None):
     idx = expecter.new_data(previously_read)
     if idx is not None:
         return idx
-
-    transport, pw = yield from asyncio.get_event_loop()\
-        .connect_read_pipe(lambda: PatternWaiter(expecter), expecter.spawn)
-
+    if not expecter.spawn.async_pw_transport:
+        pw = PatternWaiter()
+        pw.set_expecter(expecter)
+        transport, pw = yield from asyncio.get_event_loop()\
+            .connect_read_pipe(lambda: pw, expecter.spawn)
+        expecter.spawn.async_pw_transport = pw, transport
+    else:
+        pw, transport = expecter.spawn.async_pw_transport
+        pw.set_expecter(expecter)
+        transport.resume_reading()
     try:
         return (yield from asyncio.wait_for(pw.fut, timeout))
     except asyncio.TimeoutError as e:
         transport.pause_reading()
         return expecter.timeout(e)
 
+
 class PatternWaiter(asyncio.Protocol):
     transport = None
-    def __init__(self, expecter):
+
+    def set_expecter(self, expecter):
         self.expecter = expecter
         self.fut = asyncio.Future()
-    
+
     def found(self, result):
         if not self.fut.done():
             self.fut.set_result(result)

--- a/pexpect/spawnbase.py
+++ b/pexpect/spawnbase.py
@@ -115,6 +115,8 @@ class SpawnBase(object):
                 self.linesep = os.linesep.decode('ascii')
             # This can handle unicode in both Python 2 and 3
             self.write_to_stdout = sys.stdout.write
+        # storage for async transport
+        self.async_pw_transport = None
 
     def _log(self, s, direction):
         if self.logfile is not None:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     asyncio = None
 
+import gc
 import sys
 import unittest
 
@@ -55,3 +56,15 @@ class AsyncTests(PexpectTestCase):
         assert run(p.expect_exact(u'5', async=True)) == 0
         assert run(p.expect_exact([u'wpeok', u'11'], async=True)) == 1
         assert run(p.expect_exact([u'foo', pexpect.EOF], async=True)) == 1
+
+    def test_async_and_gc(self):
+        p = pexpect.spawn('%s sleep_for.py 1' % sys.executable, encoding='utf8')
+        assert run(p.expect_exact(u'READY', async=True)) == 0
+        gc.collect()
+        assert run(p.expect_exact(u'END', async=True)) == 0
+
+    def test_async_and_sync(self):
+        p = pexpect.spawn('echo 1234', encoding='utf8', maxread=1)
+        assert run(p.expect_exact(u'1', async=True)) == 0
+        assert p.expect_exact(u'2') == 0
+        assert run(p.expect_exact(u'3', async=True)) == 0


### PR DESCRIPTION
_UnixReadPipeTransport class closes pipe in __del__ method. This commit
adds attribute to SpawnBase with pointer to current transport.
