### PR TITLE
Raise ExceptionPexpect instead of PtyProcessError in spawn.close

### DIFF
--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -315,7 +315,10 @@ class spawn(SpawnBase):
         and SIGINT). '''
 
         self.flush()
-        self.ptyproc.close(force=force)
+        with _wrap_ptyprocess_err():
+            # PtyProcessError may be raised if it is not possible to terminate
+            # the child.
+            self.ptyproc.close(force=force)
         self.isalive()  # Update exit status from ptyproc
         self.child_fd = -1
 


### PR DESCRIPTION
Pull request to solve issue described in https://github.com/pexpect/pexpect/issues/383.

//Kristopher
