### PR TITLE
(minor) Remove spawnu in spawn docstring in favour of spawn with encoding arg

### DIFF
--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -106,8 +106,9 @@ class spawn(SpawnBase):
             child = pexpect.spawn('some_command')
             child.logfile = sys.stdout
 
-            # In Python 3, spawnu should be used to give str to stdout:
-            child = pexpect.spawnu('some_command')
+            # In Python 3, spawn with the argument ``encoding`` should be used to ensure utf-8 
+            encoded data is sent to stdout:
+            child = pexpect.spawn('some_command', encoding='utf-8')
             child.logfile = sys.stdout
 
         The logfile_read and logfile_send members can be used to separately log


### PR DESCRIPTION
Update docstring for class `spawn.__init__` in pty_spawn.py to remove reference to deprecated spawnu in favour of spawn with ``encoding`` keyword argument

``spawnu`` deprecated according to line 805 of `pty_spawn.py` and issue #159