### PR TITLE
:bug: Fix missing module when on windows machine

### DIFF
--- a/pexpect/__init__.py
+++ b/pexpect/__init__.py
@@ -74,6 +74,8 @@ if sys.platform != 'win32':
     # On Unix, these are available at the top level for backwards compatibility
     from .pty_spawn import spawn, spawnu
     from .run import run, runu
+else:
+	import popen_spawn
 
 __version__ = '4.2.1'
 __revision__ = ''


### PR DESCRIPTION
Gives access to `pexpect.popen_spawn.PopenSpawn` in windows

Closes #391 