### PR TITLE
Raise a timeout exception if auto_prompt_reset is True

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -230,7 +230,7 @@ class pxssh (spawn):
     def login (self, server, username, password='', terminal_type='ansi',
                 original_prompt=r"[#$]", login_timeout=10, port=None,
                 auto_prompt_reset=True, ssh_key=None, quiet=True,
-                sync_multiplier=1, check_local_ip=True, bail_on_timeout=False):
+                sync_multiplier=1, check_local_ip=True):
         '''This logs the user into the given server.
 
         It uses
@@ -324,7 +324,7 @@ class pxssh (spawn):
             #can't be sure, but it's safe to guess that we did login because if
             #I presume wrong and we are not logged in then this should be caught
             #later when I try to set the shell prompt.
-            if bail_on_timeout:
+            if not auto_prompt_reset:
                 raise ExceptionPxssh('connection timeout')
             pass
         elif i==6: # Connection closed by remote host

--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -230,7 +230,7 @@ class pxssh (spawn):
     def login (self, server, username, password='', terminal_type='ansi',
                 original_prompt=r"[#$]", login_timeout=10, port=None,
                 auto_prompt_reset=True, ssh_key=None, quiet=True,
-                sync_multiplier=1, check_local_ip=True):
+                sync_multiplier=1, check_local_ip=True, bail_on_timeout=False):
         '''This logs the user into the given server.
 
         It uses
@@ -324,6 +324,8 @@ class pxssh (spawn):
             #can't be sure, but it's safe to guess that we did login because if
             #I presume wrong and we are not logged in then this should be caught
             #later when I try to set the shell prompt.
+            if bail_on_timeout:
+                raise ExceptionPxssh('connection timeout')
             pass
         elif i==6: # Connection closed by remote host
             self.close()


### PR DESCRIPTION
I would like to see something like this.  We connect to routers with pxssh and so we cannot rely on the prompt setting to catch a timed out connection.  If I try to connect to a firewalled router with auto_prompt_reset=False then it times out with no error and I try to talk to something that isn't there.  The thing is... none of that actually throws an error, it just acts like I'm talking to something without much to say.