### PR TITLE
added missing assignment of pid var to PopenSpawn class

### DIFF
--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -43,6 +43,7 @@ class PopenSpawn(SpawnBase):
             cmd = shlex.split(cmd)
 
         self.proc = subprocess.Popen(cmd, **kwargs)
+        self.pid = self.proc.pid
         self.closed = False
         self._buf = self.string_type()
 


### PR DESCRIPTION
The pid of the class PopenSpawn has always returned None because it was never assigned