### PR TITLE
Use raw strings for strings with literal backslash

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -114,12 +114,12 @@ class pxssh (spawn):
         #prompt command different than the regex.
 
         # used to match the command-line prompt
-        self.UNIQUE_PROMPT = "\[PEXPECT\][\$\#] "
+        self.UNIQUE_PROMPT = r"\[PEXPECT\][\$\#] "
         self.PROMPT = self.UNIQUE_PROMPT
 
         # used to set shell command-line prompt to UNIQUE_PROMPT.
-        self.PROMPT_SET_SH = "PS1='[PEXPECT]\$ '"
-        self.PROMPT_SET_CSH = "set prompt='[PEXPECT]\$ '"
+        self.PROMPT_SET_SH = r"PS1='[PEXPECT]\$ '"
+        self.PROMPT_SET_CSH = r"set prompt='[PEXPECT]\$ '"
         self.SSH_OPTS = ("-o'RSAAuthentication=no'"
                 + " -o 'PubkeyAuthentication=no'")
 # Disabling host key checking, makes you vulnerable to MITM attacks.


### PR DESCRIPTION
In python 3.6 it raises a DeprecationWarning to have strings with invalid backslash escape sequences. Changing the strings to raw strings (that doesn't try to look for escape sequences) makes the intention clearer and shuts up the DeprecationWarning