### PR TITLE
Fix popen_spawn when specifying a path on Windows which contains "\" …

### DIFF
--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -41,7 +41,7 @@ class PopenSpawn(SpawnBase):
             kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
 
         if isinstance(cmd, string_types):
-            cmd = shlex.split(cmd, posix=sys.platform != 'win32')
+            cmd = shlex.split(cmd, posix=os.name == 'posix')
 
         self.proc = subprocess.Popen(cmd, **kwargs)
         self.pid = self.proc.pid

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -41,7 +41,7 @@ class PopenSpawn(SpawnBase):
             kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
 
         if isinstance(cmd, string_types):
-            cmd = shlex.split(cmd)
+            cmd = shlex.split(cmd, posix=sys.platform != 'win32')
 
         self.proc = subprocess.Popen(cmd, **kwargs)
         self.pid = self.proc.pid


### PR DESCRIPTION
…separators