### PR TITLE
Don't split cmd strings on win32 in PopenSpawn

### DIFF
--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -40,7 +40,7 @@ class PopenSpawn(SpawnBase):
             kwargs['startupinfo'] = startupinfo
             kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
 
-        if isinstance(cmd, string_types):
+        if isinstance(cmd, string_types) and sys.platform != 'win32':
             cmd = shlex.split(cmd, posix=os.name == 'posix')
 
         self.proc = subprocess.Popen(cmd, **kwargs)


### PR DESCRIPTION
[On win32 Popen uses strings for args](https://docs.python.org/3/library/subprocess.html#converting-argument-sequence), so in PopenSpawn it isn't necessary to convert a string to a list just for Popen to convert it back again.
This also resolves an issue I was having where if the path to the executable was double quoted those quotes would stay in the first element of the cmd list and would cause Popen to throw a FileNotFoundError.