### PR TITLE
Issue #451: Check for "password:" as prompt instead of "password"

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -277,7 +277,7 @@ class pxssh (spawn):
         # This does not distinguish between a remote server 'password' prompt
         # and a local ssh 'passphrase' prompt (for unlocking a private key).
         spawn._spawn(self, cmd)
-        i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT, "(?i)connection closed by remote host", EOF], timeout=login_timeout)
+        i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password:)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT, "(?i)connection closed by remote host", EOF], timeout=login_timeout)
 
         # First phase
         if i==0:
@@ -285,13 +285,13 @@ class pxssh (spawn):
             # This is what you get if SSH does not have the remote host's
             # public key stored in the 'known_hosts' cache.
             self.sendline("yes")
-            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password:)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
         if i==2: # password or passphrase
             self.sendline(password)
-            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password:)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
         if i==4:
             self.sendline(terminal_type)
-            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password:)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
         if i==7:
             self.close()
             raise ExceptionPxssh('Could not establish connection to host')


### PR DESCRIPTION
pxssh checks for 'password' as the password prompt rather than 'password:'. This breaks things when the word 'password' is in the banner - which is rather more common than you might think. I think what is happening is, pxssh is sending the password, but then seeing the word 'password' in the banner and thinking that it has failed to log in.

This extremely simple fix should work, as long as:

1. There aren't any legitimate instances where SSH will prompt for password without a colon (I have never observed this)
2. It still doesn't cover the case where the banner actually contains the word password followed by a colon - "password:" - handling this would require a more substantial change.

I would respectfully suggest consideration of merging this pull request unless there are legitimate known situations where the password prompt comes without a colon.

Any feedback on this?