### PR TITLE
Unset PROMPT_COMMAND in bash for replwrap

### DIFF
--- a/pexpect/bashrc.sh
+++ b/pexpect/bashrc.sh
@@ -11,3 +11,6 @@ fi
 
 # Reset PS1 so pexpect can find it
 PS1="$"
+
+# Unset PROMPT_COMMAND, so that it can't change PS1 to something unexpected.
+unset PROMPT_COMMAND

--- a/pexpect/bashrc.sh
+++ b/pexpect/bashrc.sh
@@ -1,3 +1,4 @@
+# Different platforms have different names for the systemwide bashrc
 if [[ -f /etc/bashrc ]]; then
   source /etc/bashrc
 fi


### PR DESCRIPTION
People may use PROMPT_COMMAND to modify the prompt (hat-tip to @Naereen, who does). Unset it to avoid breaking replwrap.

The line between customisations that people might want to be preserved in replwrap (like aliases) and those that don't make sense (like custom prompts) is somewhat indistinct. But from the uses of PROMPT_COMMAND I've seen, I think it's more likely that it shouldn't apply in replwrap.