### PR TITLE
FIX: bad representation of bytes patterns.

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -158,7 +158,7 @@ class searcher_string(object):
         '''This returns a human-readable string that represents the state of
         the object.'''
 
-        ss = [(ns[0], '    %d: "%s"' % ns) for ns in self._strings]
+        ss = [(ns[0], '    %d: %r' % ns) for ns in self._strings]
         ss.append((-1, 'searcher_string:'))
         if self.eof_index >= 0:
             ss.append((self.eof_index, '    %d: EOF' % self.eof_index))
@@ -258,13 +258,7 @@ class searcher_re(object):
         #    (n, repr(s.pattern))) for n, s in self._searches]
         ss = list()
         for n, s in self._searches:
-            try:
-                ss.append((n, '    %d: re.compile("%s")' % (n, s.pattern)))
-            except UnicodeEncodeError:
-                # for test cases that display __str__ of searches, dont throw
-                # another exception just because stdout is ascii-only, using
-                # repr()
-                ss.append((n, '    %d: re.compile(%r)' % (n, s.pattern)))
+            ss.append((n, '    %d: re.compile(%r)' % (n, s.pattern)))
         ss.append((-1, 'searcher_re:'))
         if self.eof_index >= 0:
             ss.append((self.eof_index, '    %d: EOF' % self.eof_index))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -271,7 +271,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
         expected_output = '{0}:'.format(searcher.__name__)
         idx = 0
         for word in given_words:
-            expected_output += fmt.format(idx, '"{0}"'.format(word))
+            expected_output += fmt.format(idx, "'{0}'".format(word))
             idx += 1
         if plus is not None:
             if plus == pexpect.EOF:


### PR DESCRIPTION
I was getting:

    0: re.compile("b'^[^\r\n]*\r?\n'")
    1: re.compile("b'^--More-- or \\(q\\)uit'")
    2: re.compile("b'^\\(.*\\) #'")

So I decided to drop the `%s` and keep only the `%r`, which works equally for
str and bytes:

    >>> '    %d: re.compile(%r)' % (1, b'foo')
    "    1: re.compile(b'foo')"
    >>> '    %d: re.compile(%r)' % (1, 'foo')
    "    1: re.compile('foo')"