### PR TITLE
fix a bug causing 'spawn.before' to be truncated w/ searchwindowsize use

### DIFF
--- a/pexpect/_async.py
+++ b/pexpect/_async.py
@@ -9,6 +9,7 @@ def expect_async(expecter, timeout=None):
     # async stuff.
     previously_read = expecter.spawn.buffer
     expecter.spawn._buffer = expecter.spawn.buffer_type()
+    expecter.spawn._before = expecter.spawn.buffer_type()
     idx = expecter.new_data(previously_read)
     if idx is not None:
         return idx

--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -16,6 +16,7 @@ class Expecter(object):
 
         pos = spawn._buffer.tell()
         spawn._buffer.write(data)
+        spawn._before.write(data)
 
         # determine which chunk of data to search; if a windowsize is
         # specified, this is the *new* data + the preceding <windowsize> bytes
@@ -27,11 +28,11 @@ class Expecter(object):
             window = spawn.buffer
         index = searcher.search(window, len(data))
         if index >= 0:
-            value = spawn.buffer
             spawn._buffer = spawn.buffer_type()
-            spawn._buffer.write(value[searcher.end:])
-            spawn.before = value[: searcher.start]
-            spawn.after = value[searcher.start: searcher.end]
+            spawn._buffer.write(window[searcher.end:])
+            spawn.before = spawn._before.getvalue()[0:-(len(window) - searcher.start)]
+            spawn._before = spawn.buffer_type()
+            spawn.after = window[searcher.start: searcher.end]
             spawn.match = searcher.match
             spawn.match_index = index
             # Found a match
@@ -45,6 +46,7 @@ class Expecter(object):
 
         spawn.before = spawn.buffer
         spawn._buffer = spawn.buffer_type()
+        spawn._before = spawn.buffer_type()
         spawn.after = EOF
         index = self.searcher.eof_index
         if index >= 0:
@@ -96,6 +98,7 @@ class Expecter(object):
         try:
             incoming = spawn.buffer
             spawn._buffer = spawn.buffer_type()
+            spawn._before = spawn.buffer_type()
             while True:
                 idx = self.new_data(incoming)
                 # Keep reading until exception or return.

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -408,6 +408,17 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         p.buffer = b'Testing'
         p.sendeof ()
 
+    def test_before_across_chunks(self):
+        # https://github.com/pexpect/pexpect/issues/478
+        child = pexpect.spawn(
+            '''/bin/bash -c "openssl rand -base64 {} | head -500 | nl --number-format=rz --number-width=5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
+            searchwindowsize=128
+        )
+        child.expect(['PATTERN'])
+        assert len(child.before.splitlines()) == 500
+        assert child.after == b'PATTERN'
+        assert child.buffer == b'!!!\r\n'
+
     def _before_after(self, p):
         p.timeout = 5
 


### PR DESCRIPTION
see: https://github.com/pexpect/pexpect/issues/478