### PR TITLE
Make poll_ignore_interrupts register multiple FDs

### DIFF
--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -138,7 +138,7 @@ class fdspawn(SpawnBase):
             wlist = []
             xlist = []
             if self.use_poll:
-                rlist = poll_ignore_interrupts(rlist[0], timeout)
+                rlist = poll_ignore_interrupts(rlist, timeout)
             else:
                 rlist, wlist, xlist = select_ignore_interrupts(
                     rlist, wlist, xlist, timeout

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -447,7 +447,7 @@ class spawn(SpawnBase):
         if not self.isalive():
             # timeout of 0 means "poll"
             if self.use_poll:
-                r = poll_ignore_interrupts(self.child_fd, timeout)
+                r = poll_ignore_interrupts([self.child_fd], timeout)
             else:
                 r, w, e = select_ignore_interrupts([self.child_fd], [], [], 0)
             if not r:
@@ -458,14 +458,14 @@ class spawn(SpawnBase):
             # FIXME So does this mean Irix systems are forced to always have
             # FIXME a 2 second delay when calling read_nonblocking? That sucks.
             if self.use_poll:
-                r = poll_ignore_interrupts(self.child_fd, timeout)
+                r = poll_ignore_interrupts([self.child_fd], timeout)
             else:
                 r, w, e = select_ignore_interrupts([self.child_fd], [], [], 2)
             if not r and not self.isalive():
                 self.flag_eof = True
                 raise EOF('End Of File (EOF). Slow platform.')
         if self.use_poll:
-            r = poll_ignore_interrupts(self.child_fd, timeout)
+            r = poll_ignore_interrupts([self.child_fd], timeout)
         else:
             r, w, e = select_ignore_interrupts(
                 [self.child_fd], [], [], timeout
@@ -781,15 +781,16 @@ class spawn(SpawnBase):
 
         return os.read(fd, 1000)
 
-    def __interact_copy(self, escape_character=None,
-            input_filter=None, output_filter=None):
+    def __interact_copy(
+        self, escape_character=None, input_filter=None, output_filter=None
+    ):
 
         '''This is used by the interact() method.
         '''
 
         while self.isalive():
             if self.use_poll:
-                r = poll_ignore_interrupts(self.child_fd)
+                r = poll_ignore_interrupts([self.child_fd, self.STDIN_FILENO])
             else:
                 r, w, e = select_ignore_interrupts(
                     [self.child_fd, self.STDIN_FILENO], [], []

--- a/pexpect/utils.py
+++ b/pexpect/utils.py
@@ -156,15 +156,17 @@ def select_ignore_interrupts(iwtd, owtd, ewtd, timeout=None):
                 raise
 
 
-def poll_ignore_interrupts(fd, timeout=None):
-    '''Simple wrapper around poll to register a file descriptor and
+def poll_ignore_interrupts(fds, timeout=None):
+    '''Simple wrapper around poll to register file descriptors and
     ignore signals.'''
 
     if timeout is not None:
         end_time = time.time() + timeout
 
     poller = select.poll()
-    poller.register(fd)
+    for fd in fds:
+        poller.register(fd)
+
     while True:
         try:
             timeout_ms = None if timeout is None else timeout * 1000


### PR DESCRIPTION
Like select.select() call and fix broken __interact_copy implementation