### PR TITLE
replwrap: add async support

### DIFF
--- a/pexpect/_async.py
+++ b/pexpect/_async.py
@@ -1,5 +1,6 @@
 import asyncio
 import errno
+import signal
 
 from pexpect import EOF
 
@@ -29,6 +30,23 @@ def expect_async(expecter, timeout=None):
         transport.pause_reading()
         return expecter.timeout(e)
 
+@asyncio.coroutine
+def repl_run_command_async(repl, cmdlines, timeout=-1):
+    res = []
+    repl.child.sendline(cmdlines[0])
+    for line in cmdlines[1:]:
+        yield from repl._expect_prompt(timeout=timeout, async_=True)
+        res.append(repl.child.before)
+        repl.child.sendline(line)
+
+    # Command was fully submitted, now wait for the next prompt
+    prompt_idx = yield from repl._expect_prompt(timeout=timeout, async_=True)
+    if prompt_idx == 1:
+        # We got the continuation prompt - command was incomplete
+        repl.child.kill(signal.SIGINT)
+        yield from repl._expect_prompt(timeout=1, async_=True)
+        raise ValueError("Continuation prompt found - input was incomplete:")
+    return u''.join(res + [repl.child.before])
 
 class PatternWaiter(asyncio.Protocol):
     transport = None
@@ -41,7 +59,7 @@ class PatternWaiter(asyncio.Protocol):
         if not self.fut.done():
             self.fut.set_result(result)
             self.transport.pause_reading()
-    
+
     def error(self, exc):
         if not self.fut.done():
             self.fut.set_exception(exc)
@@ -49,7 +67,7 @@ class PatternWaiter(asyncio.Protocol):
 
     def connection_made(self, transport):
         self.transport = transport
-    
+
     def data_received(self, data):
         spawn = self.expecter.spawn
         s = spawn._decoder.decode(data)
@@ -67,7 +85,7 @@ class PatternWaiter(asyncio.Protocol):
         except Exception as e:
             self.expecter.errored()
             self.error(e)
-    
+
     def eof_received(self):
         # N.B. If this gets called, async will close the pipe (the spawn object)
         # for us
@@ -78,7 +96,7 @@ class PatternWaiter(asyncio.Protocol):
             self.error(e)
         else:
             self.found(index)
-    
+
     def connection_lost(self, exc):
         if isinstance(exc, OSError) and exc.errno == errno.EIO:
             # We may get here without eof_received being called, e.g on Linux

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -27,6 +27,13 @@ class REPLWrapTestCase(unittest.TestCase):
         res = bash.run_command("time")
         assert 'real' in res, res
 
+        try:
+            bash.run_command('')
+        except ValueError:
+            pass
+        else:
+            assert False, "Didn't raise ValueError for empty input"
+
     def test_pager_as_cat(self):
         " PAGER is set to cat, to prevent timeout in ``man sleep``. "
         bash = replwrap.bash()
@@ -78,7 +85,7 @@ class REPLWrapTestCase(unittest.TestCase):
         self.assertEqual(res.strip().splitlines(), ['1 2', '3 4'])
 
     def test_existing_spawn(self):
-        child = pexpect.spawn("bash", timeout=5, echo=False, encoding='utf-8')
+        child = pexpect.spawn("bash", timeout=5, encoding='utf-8')
         repl = replwrap.REPLWrapper(child, re.compile('[$#]'),
                                     "PS1='{0}' PS2='{1}' "
                                     "PROMPT_COMMAND=''")


### PR DESCRIPTION
Add an 'async_' argument to run_command. When True, a Future object will
be returned which *must* be awaited in asynchronous code.

Signed-off-by: Robin Jarry <robin.jarry@6wind.com>
Signed-off-by: Thomas Faivre <thomas.faivre@6wind.com>