### PR TITLE
Add note to pxssh doc inviting people to consider Paramiko

### DIFF
--- a/doc/api/pxssh.rst
+++ b/doc/api/pxssh.rst
@@ -1,6 +1,14 @@
 pxssh - control an SSH session
 ==============================
 
+.. note::
+
+   *pxssh* is a screen-scraping wrapper around the SSH command on your system.
+   In many cases, you should consider using
+   `Paramiko <https://github.com/paramiko/paramiko>`_ instead.
+   Paramiko is a Python module which speaks the SSH protocol directly, so it
+   doesn't have the extra complexity of running a local subprocess.
+
 .. automodule:: pexpect.pxssh
 
 .. autoclass:: ExceptionPxssh


### PR DESCRIPTION
cc @Red-M @jquast @jnatschev, following the discussion on #505.

Despite the issues @Red-M reported seeing, I think Paramiko is generally the better option for people who need to do things programmatically over SSH. It avoids the overhead and complexity of shelling out to ssh, and it can do more by speaking the protocol directly - e.g. it's easy to open an SFTP client on an existing connection.

I don't think there's any need to get rid of pxssh, but given that we often recommend paramiko when people have trouble with pexpect (e.g. #339, #414), it seems like a good idea to point people there in the docs.