### PR TITLE
Fix "test_bash" test

### DIFF
--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -24,8 +24,8 @@ class REPLWrapTestCase(unittest.TestCase):
 
     def test_bash(self):
         bash = replwrap.bash()
-        res = bash.run_command("time")
-        assert 'real' in res, res
+        res = bash.run_command("alias")
+        assert 'alias' in res, res
 
         try:
             bash.run_command('')


### PR DESCRIPTION
Due to an old bash version(3.x) on some systems there is no builtin "time"
command. Another more common one can be used for.

Fixes: https://github.com/pexpect/pexpect/issues/521