### PR TITLE
Fix "test_before_across_chunks" test

### DIFF
--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -411,7 +411,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
     def test_before_across_chunks(self):
         # https://github.com/pexpect/pexpect/issues/478
         child = pexpect.spawn(
-            '''/bin/bash -c "openssl rand -base64 {} | head -500 | nl --number-format=rz --number-width=5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
+            '''/bin/bash -c "openssl rand -base64 {} 2>/dev/null | head -500 | nl --number-format=rz --number-width=5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
             searchwindowsize=128
         )
         child.expect(['PATTERN'])


### PR DESCRIPTION
Pipe like "openssl rand -base64 2097152 | head -n 500" leads to "Broken pipe"
error on some systems. This is an unexpected behavior. So errors must be
suppressed.

Fixes: https://github.com/pexpect/pexpect/issues/523