### PR TITLE
tests: ignore stderr from openssl

### DIFF
--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -411,7 +411,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
     def test_before_across_chunks(self):
         # https://github.com/pexpect/pexpect/issues/478
         child = pexpect.spawn(
-            '''/bin/bash -c "openssl rand -base64 {} | head -500 | nl --number-format=rz --number-width=5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
+            '''/bin/bash -c "openssl rand -base64 {} 2>/dev/null | head -500 | nl --number-format=rz --number-width=5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
             searchwindowsize=128
         )
         child.expect(['PATTERN'])


### PR DESCRIPTION
Without this patch, the test failed with openssl-1.0.2p
because 502 lines were captured with the extra lines being at the end:
```
140510355240592:error:02012020:system library:fflush:Broken pipe:bss_file.c:434:fflush()
140510355240592:error:20074002:BIO routines:FILE_CTRL:system lib:bss_file.c:436:
```

neither openssl-1.0.2j nor 1.1.0h needed this patch.