### PR TITLE
Fixed TypeError exception when sending bytes to REPLWrapper

### DIFF
--- a/pexpect/_async.py
+++ b/pexpect/_async.py
@@ -46,7 +46,9 @@ def repl_run_command_async(repl, cmdlines, timeout=-1):
         repl.child.kill(signal.SIGINT)
         yield from repl._expect_prompt(timeout=1, async_=True)
         raise ValueError("Continuation prompt found - input was incomplete:")
-    return u''.join(res + [repl.child.before])
+    res = res + [repl.child.before]
+    sep = u'' if isinstance(res[0], str) else b''
+    return sep.join(res)
 
 class PatternWaiter(asyncio.Protocol):
     transport = None

--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -108,7 +108,10 @@ class REPLWrapper(object):
             self._expect_prompt(timeout=1)
             raise ValueError("Continuation prompt found - input was incomplete:\n"
                              + "{}".format(command))
-        return u''.join(res + [self.child.before])
+
+        res = res + [self.child.before]
+        sep = u'' if isinstance(res[0], str) else b''
+        return sep.join(res)
 
 def python(command="python"):
     """Start a Python shell and return a :class:`REPLWrapper` object."""

--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -83,8 +83,10 @@ class REPLWrapper(object):
         # Split up multiline commands and feed them in bit-by-bit
         cmdlines = command.splitlines()
         # splitlines ignores trailing newlines - add it back in manually
-        if command.endswith('\n'):
+        if isinstance(command, str) and command.endswith('\n'):
             cmdlines.append('')
+        elif isinstance(command, bytes) and command.endswith(b'\n'):
+            cmdlines.append(b'')
         if not cmdlines:
             raise ValueError("No command was given")
 
@@ -105,7 +107,7 @@ class REPLWrapper(object):
             self.child.kill(signal.SIGINT)
             self._expect_prompt(timeout=1)
             raise ValueError("Continuation prompt found - input was incomplete:\n"
-                             + command)
+                             + "{}".format(command))
         return u''.join(res + [self.child.before])
 
 def python(command="python"):

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -125,7 +125,7 @@ class REPLWrapTestCase(unittest.TestCase):
         py = replwrap.REPLWrapper(child, ">>> ", prompt_change=None,
                                   continuation_prompt=u"... ")
 
-        res = py.run_command(b'\x34\x2b\x37')
+        res = py.run_command(b'\x34\x2b\x37\n')
         assert res.strip() == b'11'
 
 if __name__ == '__main__':

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -117,5 +117,22 @@ class REPLWrapTestCase(unittest.TestCase):
         res = py.run_command("for a in range(3): print(a)\n")
         assert res.strip().splitlines() == ['0', '1', '2']
 
+    def test_run_command_bytes(self):
+        bash = replwrap.bash()
+        res = bash.run_command(b"echo '1 2\n3 4'")
+        self.assertEqual(res.strip().splitlines(), [b'1 2', b'3 4'])
+
+        # Should raise ValueError if input is incomplete
+        try:
+            bash.run_command(b"echo '5 6")
+        except ValueError:
+            pass
+        else:
+            assert False, "Didn't raise ValueError for incomplete input"
+
+        # Check that the REPL was reset (SIGINT) after the incomplete input
+        res = bash.run_command(b"echo '1 2\n3 4'")
+        self.assertEqual(res.strip().splitlines(), [b'1 2', b'3 4'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a fix for issue #531, which was opened by me just yesterday.

I added a check for type, to the newline check on `command`, a format string when `command` is used in an exception message below, and a test method for the new functionality, which I copied and changed a little from `test_multiline` in the same file.