### PR TITLE
Clarification for Python3 users in overview.rst.

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -209,6 +209,9 @@ following will turn on logging and send output to stdout (the screen)::
     child = pexpect.spawn(foo)
     child.logfile = sys.stdout
 
+You will need to pass an encoding to spawn in the above code if you are using
+Python 3, or use sys.stdout.buffer.
+
 Exceptions
 ----------
 


### PR DESCRIPTION
In the API overview, I added a mention of the encoding argument for the
spawn class when using Python 3.

I know this is covered in the spawn class docs, but this would help
first-time users trying out the example code. It would also help
occasional users, like me, who go to the overview for a quick refresher.

I copied the line from the spawn class "child.logfile_read" example, and
added a reference to sys.stdout.buffer, which was not obvious to me.

I wonder if this is not clear enough - should this include a Python 3 specific 
example? As Python 3 is increasingly the default Python.