### PR TITLE
add use_poll to pxssh

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -118,12 +118,12 @@ class pxssh (spawn):
     def __init__ (self, timeout=30, maxread=2000, searchwindowsize=None,
                     logfile=None, cwd=None, env=None, ignore_sighup=True, echo=True,
                     options={}, encoding=None, codec_errors='strict',
-                    debug_command_string=False):
+                    debug_command_string=False, use_poll=False):
 
         spawn.__init__(self, None, timeout=timeout, maxread=maxread,
                        searchwindowsize=searchwindowsize, logfile=logfile,
                        cwd=cwd, env=env, ignore_sighup=ignore_sighup, echo=echo,
-                       encoding=encoding, codec_errors=codec_errors)
+                       encoding=encoding, codec_errors=codec_errors, use_poll=use_poll)
 
         self.name = '<pxssh>'
 


### PR DESCRIPTION
Add the use_poll option to use pxssh with >1024 FDs.