### PR TITLE
Always use self.PYTHONBIN not 'python' or sys.executable in tests

### DIFF
--- a/tests/interact.py
+++ b/tests/interact.py
@@ -31,7 +31,12 @@ import sys
 
 
 def main():
-    p = pexpect.spawn('{sys.executable} getch.py'.format(sys=sys),
+    if len(sys.argv) > 1 and '--pythonbin' in sys.argv:
+        pythonbin = sys.argv[sys.argv.index('--pythonbin') + 1]
+    else:
+        pythonbin = sys.executable
+        
+    p = pexpect.spawn('{pythonbin} getch.py'.format(pythonbin=pythonbin),
                       env=no_coverage_env())
 
     # defaults matches api

--- a/tests/interact.py
+++ b/tests/interact.py
@@ -31,12 +31,7 @@ import sys
 
 
 def main():
-    if len(sys.argv) > 1 and '--pythonbin' in sys.argv:
-        pythonbin = sys.argv[sys.argv.index('--pythonbin') + 1]
-    else:
-        pythonbin = sys.executable
-        
-    p = pexpect.spawn('{pythonbin} getch.py'.format(pythonbin=pythonbin),
+    p = pexpect.spawn('{sys.executable} getch.py'.format(sys=sys),
                       env=no_coverage_env())
 
     # defaults matches api

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -47,19 +47,19 @@ class AsyncTests(PexpectTestCase):
             run(coro)
 
     def test_expect_exact(self):
-        p = pexpect.spawn('%s list100.py' % sys.executable)
+        p = pexpect.spawn('%s list100.py' % self.PYTHONBIN)
         assert run(p.expect_exact(b'5', async_=True)) == 0
         assert run(p.expect_exact(['wpeok', b'11'], async_=True)) == 1
         assert run(p.expect_exact([b'foo', pexpect.EOF], async_=True)) == 1
 
     def test_async_utf8(self):
-        p = pexpect.spawn('%s list100.py' % sys.executable, encoding='utf8')
+        p = pexpect.spawn('%s list100.py' % self.PYTHONBIN, encoding='utf8')
         assert run(p.expect_exact(u'5', async_=True)) == 0
         assert run(p.expect_exact([u'wpeok', u'11'], async_=True)) == 1
         assert run(p.expect_exact([u'foo', pexpect.EOF], async_=True)) == 1
 
     def test_async_and_gc(self):
-        p = pexpect.spawn('%s sleep_for.py 1' % sys.executable, encoding='utf8')
+        p = pexpect.spawn('%s sleep_for.py 1' % self.PYTHONBIN, encoding='utf8')
         assert run(p.expect_exact(u'READY', async_=True)) == 0
         gc.collect()
         assert run(p.expect_exact(u'END', async_=True)) == 0

--- a/tests/test_ctrl_chars.py
+++ b/tests/test_ctrl_chars.py
@@ -36,11 +36,14 @@ else:
     byte = chr
 
 class TestCtrlChars(PexpectTestCase.PexpectTestCase):
+    def setUp(self):
+        super(TestCtrlChars, self).setUp()
+        self.getch_cmd = self.PYTHONBIN + ' getch.py'
 
     def test_control_chars(self):
         '''This tests that we can send all 256 8-bit characters to a child
         process.'''
-        child = pexpect.spawn('python getch.py', echo=False, timeout=5)
+        child = pexpect.spawn(self.getch_cmd, echo=False, timeout=5)
         child.expect('READY')
         for i in range(1, 256):
             child.send(byte(i))
@@ -54,7 +57,7 @@ class TestCtrlChars(PexpectTestCase.PexpectTestCase):
         assert child.exitstatus == 0
 
     def test_sendintr (self):
-        child = pexpect.spawn('python getch.py', echo=False, timeout=5)
+        child = pexpect.spawn(self.getch_cmd, echo=False, timeout=5)
         child.expect('READY')
         child.sendintr()
         child.expect(str(ord(ptyprocess._INTR)) + '<STOP>')
@@ -66,7 +69,7 @@ class TestCtrlChars(PexpectTestCase.PexpectTestCase):
         assert child.exitstatus == 0
 
     def test_sendeof(self):
-        child = pexpect.spawn('python getch.py', echo=False, timeout=5)
+        child = pexpect.spawn(self.getch_cmd, echo=False, timeout=5)
         child.expect('READY')
         child.sendeof()
         child.expect(str(ord(ptyprocess._EOF)) + '<STOP>')
@@ -80,14 +83,14 @@ class TestCtrlChars(PexpectTestCase.PexpectTestCase):
     def test_bad_sendcontrol_chars (self):
         '''This tests that sendcontrol will return 0 for an unknown char. '''
 
-        child = pexpect.spawn('python getch.py', echo=False, timeout=5)
+        child = pexpect.spawn(self.getch_cmd, echo=False, timeout=5)
         child.expect('READY')
         assert 0 == child.sendcontrol('1')
 
     def test_sendcontrol(self):
         '''This tests that we can send all special control codes by name.
         '''
-        child = pexpect.spawn('python getch.py', echo=False, timeout=5)
+        child = pexpect.spawn(self.getch_cmd, echo=False, timeout=5)
         child.expect('READY')
         for ctrl in 'abcdefghijklmnopqrstuvwxyz':
             assert child.sendcontrol(ctrl) == 1

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -42,8 +42,6 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
             env['PYTHONPATH'] = self.project_dir
 
         self.interact_py = ('{self.PYTHONBIN} interact.py'.format(self=self))
-        if self.PYTHONBIN != sys.executable:
-            self.interact_py += ' --pythonbin {self.PYTHONBIN}'.format(self=self)
 
     def test_interact_escape(self):
         " Ensure `escape_character' value exits interactive mode. "

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -42,6 +42,8 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
             env['PYTHONPATH'] = self.project_dir
 
         self.interact_py = ('{self.PYTHONBIN} interact.py'.format(self=self))
+        if self.PYTHONBIN != sys.executable:
+            self.interact_py += ' --pythonbin {self.PYTHONBIN}'.format(self=self)
 
     def test_interact_escape(self):
         " Ensure `escape_character' value exits interactive mode. "

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -41,7 +41,7 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         else:
             env['PYTHONPATH'] = self.project_dir
 
-        self.interact_py = ('{sys.executable} interact.py'.format(sys=sys))
+        self.interact_py = ('{self.PYTHONBIN} interact.py'.format(self=self))
 
     def test_interact_escape(self):
         " Ensure `escape_character' value exits interactive mode. "

--- a/tests/test_isalive.py
+++ b/tests/test_isalive.py
@@ -57,7 +57,7 @@ class IsAliveTestCase(PexpectTestCase.PexpectTestCase):
         '''Test calling wait with a process terminated by a signal.'''
         if not hasattr(signal, 'SIGALRM'):
             return 'SKIP'
-        p = pexpect.spawn(sys.executable, ['alarm_die.py'])
+        p = pexpect.spawn(self.PYTHONBIN, ['alarm_die.py'])
         p.wait()
         assert p.exitstatus is None
         self.assertEqual(p.signalstatus, signal.SIGALRM)
@@ -99,7 +99,7 @@ class IsAliveTestCase(PexpectTestCase.PexpectTestCase):
         assert not p.isalive()
 
     def test_forced_terminate(self):
-        p = pexpect.spawn(sys.executable, ['needs_kill.py'])
+        p = pexpect.spawn(self.PYTHONBIN, ['needs_kill.py'])
         p.expect('READY')
         assert p.terminate(force=True) == True
         p.expect(pexpect.EOF)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -171,7 +171,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
 
     def test_with(self):
         "spawn can be used as a context manager"
-        with pexpect.spawn(sys.executable + ' echo_w_prompt.py') as p:
+        with pexpect.spawn(self.PYTHONBIN + ' echo_w_prompt.py') as p:
             p.expect('<in >')
             p.sendline(b'alpha')
             p.expect(b'<out>alpha')
@@ -187,7 +187,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
 
     def test_sighup(self):
         " validate argument `ignore_sighup=True` and `ignore_sighup=False`. "
-        getch = sys.executable + ' getch.py'
+        getch = self.PYTHONBIN + ' getch.py'
         child = pexpect.spawn(getch, ignore_sighup=True)
         child.expect('READY')
         child.kill(signal.SIGHUP)

--- a/tests/test_pxssh.py
+++ b/tests/test_pxssh.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python
 import os
+import shutil
 import tempfile
 import unittest
 
 from pexpect import pxssh
+from .PexpectTestCase import PexpectTestCase
 
-class SSHTestBase(unittest.TestCase):
+class SSHTestBase(PexpectTestCase):
     def setUp(self):
+        super(SSHTestBase, self).setUp()
+        self.tempdir = tempfile.mkdtemp()
         self.orig_path = os.environ.get('PATH')
+        os.symlink(self.PYTHONBIN, os.path.join(self.tempdir, 'python'))
         fakessh_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'fakessh'))
-        os.environ['PATH'] = fakessh_dir + \
+        os.environ['PATH'] = self.tempdir + os.pathsep + fakessh_dir + \
                     ((os.pathsep + self.orig_path) if self.orig_path else '')
 
     def tearDown(self):
+        shutil.rmtree(self.tempdir)
         if self.orig_path:
             os.environ['PATH'] = self.orig_path
         else:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -181,7 +181,7 @@ class RunUnicodeFuncTestCase(RunFuncTestCase):
             else:
                 return True  # Stop the child process
 
-        output = pexpect.runu(sys.executable + ' echo_w_prompt.py',
+        output = pexpect.runu(self.PYTHONBIN + ' echo_w_prompt.py',
                               env={'PYTHONIOENCODING': 'utf-8'},
                               events={pattern: callback})
         assert isinstance(output, unicode_type), type(output)


### PR DESCRIPTION
Support cases where self.PYTHONBIN != sys.executable, by consistently using self.PYTHONBIN in tests.  Then, anyone who has a problematic value for sys.executable only needs to edit PexpectTestCase in a local patch (much smaller local patch to maintain).