### PR TITLE
Fix test_ansi.py when running in a non-writable directory

### DIFF
--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -121,19 +121,19 @@ class ansiTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_torturet (self):
         s = ANSI.ANSI (24,80)
+        with open('torturet.vt') as f:
+            sample_text = f.read()
         # This causes ANSI.py's DoLog to write in the cwd.  Make sure we're in a
         # writeable directory.
         d = tempfile.mkdtemp()
         old_cwd = os.getcwd()
         os.chdir(d)
         try:
-            with open('torturet.vt') as f:
-                sample_text = f.read()
+            for c in sample_text:
+                 s.process (c)
         finally:
             os.chdir(old_cwd)
             shutil.rmtree(d)
-        for c in sample_text:
-            s.process (c)
         assert s.pretty() == torture_target, 'processed: \n' + s.pretty() + '\nexpected:\n' + torture_target
 
     def test_tetris (self):

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -21,7 +21,10 @@ PEXPECT LICENSE
 from pexpect import ANSI
 import unittest
 from . import PexpectTestCase
+import os
+import shutil
 import sys
+import tempfile
 
 PY3 = (sys.version_info[0] >= 3)
 
@@ -118,8 +121,17 @@ class ansiTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_torturet (self):
         s = ANSI.ANSI (24,80)
-        with open('torturet.vt') as f:
-            sample_text = f.read()
+        # This causes ANSI.py's DoLog to write in the cwd.  Make sure we're in a
+        # writeable directory.
+        d = tempfile.mkdtemp()
+        old_cwd = os.getcwd()
+        os.chdir(d)
+        try:
+            with open('torturet.vt') as f:
+                sample_text = f.read()
+        finally:
+            os.chdir(old_cwd)
+            shutil.rmtree(d)
         for c in sample_text:
             s.process (c)
         assert s.pretty() == torture_target, 'processed: \n' + s.pretty() + '\nexpected:\n' + torture_target


### PR DESCRIPTION
Minor fix, test_ansi causes ANSI.py's DoLog to write to cwd.

If the test directory is not writable, this fails.  It should run from a tempdir.