### PR TITLE
s/xrange/range/ for Python3

### DIFF
--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -38,7 +38,7 @@ from .utils import no_coverage_env
 FILTER=''.join([(len(repr(chr(x)))==3) and chr(x) or '.' for x in range(256)])
 def hex_dump(src, length=16):
     result=[]
-    for i in xrange(0, len(src), length):
+    for i in range(0, len(src), length):
        s = src[i:i+length]
        hexa = ' '.join(["%02X"%ord(x) for x in s])
        printable = s.translate(FILTER)


### PR DESCRIPTION
This is broken for Python3, but the routine is only called on test failure, so it doesn't cause the Python3 tests to fail.