### PR TITLE
Make login_timeout functional

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -313,6 +313,7 @@ class pxssh (spawn):
         session_init_regex_array.extend(session_regex_array)
         session_init_regex_array.extend(["(?i)connection closed by remote host", EOF])
 
+        self.options['CommandTimeout'] = login_timeout - 1 # Set the timeout option on the ssh command as well, and make sure it fires first
         ssh_options = ''.join([" -o '%s=%s'" % (o, v) for (o, v) in self.options.items()])
         if quiet:
             ssh_options = ssh_options + ' -q'


### PR DESCRIPTION
The ssh terminal has it's own timeout option called 'CommandTimeout'. There are
scenarios where the ssh command is still trying to connect when pxssh times out.

In this case, pxssh assumes a successfull connection and returns True, even though
no authentication has happened yet. Subsequent calls to sendline and expect()
might get EOF or TIMEOUT errors. This leaves the user confused why an EOF occured
after the login() completed successfully.