### PR TITLE
Update doc: Wexpect is maintained

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -264,6 +264,8 @@ When run by ``PopenSpawn``, they may behave differently.
 
 .. seealso::
 
-   `winpexpect <https://pypi.python.org/pypi/winpexpect>`__ and `wexpect <https://gist.github.com/anthonyeden/8488763>`__
-     Two unmaintained pexpect-like modules for Windows, which work with a
-     hidden console.
+   `wexpect <https://pypi.org/project/wexpect/>`__ is a maintained
+   alternative for Windows. It supports pyton3.x
+   
+   `winpexpect <https://pypi.python.org/pypi/winpexpect>`__ is unmaintained
+   pexpect-like module, which work with a hidden console.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -264,8 +264,6 @@ When run by ``PopenSpawn``, they may behave differently.
 
 .. seealso::
 
-   `wexpect <https://pypi.org/project/wexpect/>`__ is a maintained
-   alternative for Windows. It supports pyton3.x
-   
-   `winpexpect <https://pypi.python.org/pypi/winpexpect>`__ is unmaintained
-   pexpect-like module, which work with a hidden console.
+   `wexpect <https://pypi.org/project/wexpect/>`__ is an
+   alternative for Windows, which works with a hidden console.
+  


### PR DESCRIPTION
Wexpect is a maintained (almost for a year) alternative of pexpect for Windows.
 - All (non-Linux specific) pexpect testcases passes with
 - ~80% coverage