### PR TITLE
Do not directly call python and use sys.executable

### DIFF
--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -108,7 +108,7 @@ class REPLWrapper(object):
                              + command)
         return u''.join(res + [self.child.before])
 
-def python(command="python"):
+def python(command=sys.executable):
     """Start a Python shell and return a :class:`REPLWrapper` object."""
     return REPLWrapper(command, u">>> ", u"import sys; sys.ps1={0!r}; sys.ps2={1!r}")
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -45,7 +45,7 @@ class PerformanceTestCase (PexpectTestCase.PexpectTestCase):
             return 'for n in range(1, %d+1): print(n)' % n
 
     def plain_range(self, n):
-        e = pexpect.spawn('python', timeout=100)
+        e = pexpect.spawn(sys.executable, timeout=100)
         self.assertEqual(e.expect(b'>>>'), 0)
         e.sendline(self._iter_n(n))
         self.assertEqual(e.expect(br'\.{3}'), 0)
@@ -53,7 +53,7 @@ class PerformanceTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(e.expect([b'inquisition', '%d' % n]), 1)
 
     def window_range(self, n):
-        e = pexpect.spawn('python', timeout=100)
+        e = pexpect.spawn(sys.executable, timeout=100)
         self.assertEqual(e.expect(b'>>>'), 0)
         e.sendline(self._iter_n(n))
         self.assertEqual(e.expect(r'\.{3}'), 0)
@@ -61,7 +61,7 @@ class PerformanceTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(e.expect([b'inquisition', '%d' % n], searchwindowsize=20), 1)
 
     def exact_range(self, n):
-        e = pexpect.spawn('python', timeout=100)
+        e = pexpect.spawn(sys.executable, timeout=100)
         self.assertEqual(e.expect_exact([b'>>>']), 0)
         e.sendline(self._iter_n(n))
         self.assertEqual(e.expect_exact([b'...']), 0)
@@ -69,7 +69,7 @@ class PerformanceTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(e.expect_exact([b'inquisition', '%d' % n],timeout=520), 1)
 
     def ewin_range(self, n):
-        e = pexpect.spawn('python', timeout=100)
+        e = pexpect.spawn(sys.executable, timeout=100)
         self.assertEqual(e.expect_exact([b'>>>']), 0)
         e.sendline(self._iter_n(n))
         self.assertEqual(e.expect_exact([b'...']), 0)
@@ -77,7 +77,7 @@ class PerformanceTestCase (PexpectTestCase.PexpectTestCase):
         self.assertEqual(e.expect_exact([b'inquisition', '%d' % n], searchwindowsize=20), 1)
 
     def faster_range(self, n):
-        e = pexpect.spawn('python', timeout=100)
+        e = pexpect.spawn(sys.executable, timeout=100)
         self.assertEqual(e.expect(b'>>>'), 0)
         e.sendline(('list(range(1, %d+1))' % n).encode('ascii'))
         self.assertEqual(e.expect([b'inquisition', '%d' % n]), 1)

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -2,6 +2,7 @@ import platform
 import unittest
 import re
 import os
+import sys
 
 import pexpect
 from pexpect import replwrap
@@ -108,7 +109,7 @@ class REPLWrapTestCase(unittest.TestCase):
         if platform.python_implementation() == 'PyPy':
             raise unittest.SkipTest(skip_pypy)
 
-        child = pexpect.spawn('python', echo=False, timeout=5, encoding='utf-8')
+        child = pexpect.spawn(sys.executable, echo=False, timeout=5, encoding='utf-8')
         # prompt_change=None should mean no prompt change
         py = replwrap.REPLWrapper(child, u">>> ", prompt_change=None,
                                   continuation_prompt=u"... ")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -69,7 +69,7 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
         super(RunFuncTestCase, self).tearDown()
 
     def test_run_exit(self):
-        (data, exitstatus) = self.runfunc('python exit1.py', withexitstatus=1)
+        (data, exitstatus) = self.runfunc(sys.executable + ' exit1.py', withexitstatus=1)
         assert exitstatus == 1, "Exit status of 'python exit1.py' should be 1."
 
     def test_run(self):


### PR DESCRIPTION
This makes sure the tests and wrapper works on systems where there
is no python2 nor /usr/bin/python available