### PR TITLE
REPLWrapTestCase.test_bash_env(): export variable PS1

### DIFF
--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -45,6 +45,7 @@ class REPLWrapTestCase(unittest.TestCase):
         """env, which displays PS1=..., should not mess up finding the prompt.
         """
         bash = replwrap.bash()
+        res = bash.run_command("export PS1")
         res = bash.run_command("env")
         self.assertIn('PS1', res)
         res = bash.run_command("echo $HOME")


### PR DESCRIPTION
The test test_bash_env() relies on PS1 being an environment variable.
Therefore, `export PS1` making it always an environment variable.
Before this, the test relied on the users bashrc to do this.

The variable PS1 is (by default) not an _environment_ variable and thus
not shown by `env`. Any variable can be made into an environment
variable by exporting it. Some people do this for PS1 in their bashrc.

Closes: #631