### PR TITLE
fix `test_pager_as_cat` test case on Solaris

### DIFF
--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -39,7 +39,7 @@ class REPLWrapTestCase(unittest.TestCase):
         " PAGER is set to cat, to prevent timeout in ``man sleep``. "
         bash = replwrap.bash()
         res = bash.run_command('man sleep', timeout=5)
-        assert 'NAME' in res, res
+        assert 'SLEEP' in res.upper(), res
 
     def test_bash_env(self):
         """env, which displays PS1=..., should not mess up finding the prompt.

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -39,7 +39,7 @@ class REPLWrapTestCase(unittest.TestCase):
         " PAGER is set to cat, to prevent timeout in ``man sleep``. "
         bash = replwrap.bash()
         res = bash.run_command('man sleep', timeout=5)
-        assert 'SLEEP' in res, res
+        assert 'NAME' in res, res
 
     def test_bash_env(self):
         """env, which displays PS1=..., should not mess up finding the prompt.


### PR DESCRIPTION
On Solaris (and possibly other systems as I don't think this is standardized), the `sleep` manual page uses a lowercase name in the header, hence `SLEEP` is not found.

After this change, the test case will look for the section name, which AFAICT is always uppercase.

Alternatively, the `assert` can be changed to something like this:
`assert 'SLEEP' in res.upper(), res`

EDIT: The section name approach doesn't work (not sure why it seemed to work yesterday), so I changed it to the `res.upper()` approach instead. Thinking about that now, it is more robust and platform independent as well.