### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -57,7 +57,7 @@ class PopenSpawn(SpawnBase):
 
         self._read_queue = Queue()
         self._read_thread = threading.Thread(target=self._read_incoming)
-        self._read_thread.setDaemon(True)
+        self._read_thread.daemon = True
         self._read_thread.start()
 
     _read_reached_eof = False


### PR DESCRIPTION
Fixes #683 