### PR TITLE
switch to get_running_loop from get_event_loop to clear deprecation warning in python 3.10

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,7 +12,7 @@ from pexpect import replwrap
 from .PexpectTestCase import PexpectTestCase
 
 def run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.get_running_loop().run_until_complete(coro)
 
 @unittest.skipIf(asyncio is None, "Requires asyncio")
 class AsyncTests(PexpectTestCase):


### PR DESCRIPTION
Fixes #686