### PR TITLE
pxssh.login: allow using implicit SSH configuration

### DIFF
--- a/pexpect/pxssh.py
+++ b/pexpect/pxssh.py
@@ -360,9 +360,8 @@ class pxssh (spawn):
 
         if username is not None:
             ssh_options = ssh_options + ' -l ' + username
-        elif ssh_config is None:
-            raise TypeError('login() needs either a username or an ssh_config')
-        else:  # make sure ssh_config has an entry for the server with a username
+        # If ssh_config was provided, make sure it has an entry for the server with a username.
+        elif ssh_config is not None:
             with open(ssh_config, 'rt') as f:
                 lines = [l.strip() for l in f.readlines()]
 

--- a/tests/test_pxssh.py
+++ b/tests/test_pxssh.py
@@ -99,16 +99,6 @@ class PxsshTestCase(SSHTestBase):
         if not '-F '+config_path in string:
             assert False, 'String generated from SSH config passing is incorrect.'
 
-    def test_username_or_ssh_config(self):
-        try:
-            ssh = pxssh.pxssh(debug_command_string=True)
-            temp_file = tempfile.NamedTemporaryFile()
-            config_path = temp_file.name
-            string = ssh.login('server')
-            raise AssertionError('Should have failed due to missing username and missing ssh_config.')
-        except TypeError:
-            pass
-
     def test_ssh_config_user(self):
         ssh = pxssh.pxssh(debug_command_string=True)
         temp_file = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
With OpenSSH clients, configuration data can come from multiple
sources (see man ssh_config):
1.   command-line options
2.   user's configuration file (~/.ssh/config)
3.   system-wide configuration file (/etc/ssh/ssh_config)

This means for example that the configuration for a particular host
could come from a user-defined configuration file, while for another
host it comes from the system-wide configuration file.

Besides, pexpect forces the use of either a username, or a specific
configuration file that will be parsed and checked for the host (among
other things).

As a consequence, it's currently not possible to use pexpect like a
regular OpenSSH client would be used, with multiple hosts potentially
defined in different configuration files.

To address this issue, instead of forcing the use of either a username
or a configuration file, just let the ssh client handle it. Also
remove the associated test.

This also allows the configuration files that are implicitly used to
contain more complex directives that are not currently supported when
parsing `ssh_config` (e.g. the `Include` directive).
