### PR TITLE
All missing close method to PopenSpawn class

### DIFF
--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -186,3 +186,7 @@ class PopenSpawn(SpawnBase):
     def sendeof(self):
         '''Closes the stdin pipe from the writing end.'''
         self.proc.stdin.close()
+
+    def close(self):
+        with self.proc:
+            self.wait()


### PR DESCRIPTION
Hi.

I've tried to use `PopenSpawn` class like this:
```
with PopenSpawn(...) as proc:
  proc.expect("mystring")
```

But got an exception:
```
Exception in Future <Task finished name='Task-138' coro=<BaseHandler.spawn_single_user.<locals>.finish_user_spawn() done, defined at /usr/local/lib/python3.8/site-packages/jupyterhub/handlers/base.py:900> exception=AttributeError("'PopenSpawn' object has no attribute 'close'")> after timeout
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/site-packages/tornado/gen.py", line 618, in error_callback
        future.result()
      File "/usr/local/lib/python3.8/site-packages/jupyterhub/handlers/base.py", line 907, in finish_user_spawn
        await spawn_future
      File "/usr/local/lib/python3.8/site-packages/jupyterhub/user.py", line 736, in spawn
        raise e
      File "/usr/local/lib/python3.8/site-packages/jupyterhub/user.py", line 635, in spawn
        url = await gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
      File "/usr/local/lib/python3.8/site-packages/sshtools/sshspawner.py", line 790, in start
        if not await maybe_future(self.check_ssh_connection(host, fail=False)):
      File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/usr/local/lib/python3.8/site-packages/sshtools/sshspawner.py", line 456, in check_ssh_connection
        return False
      File "/usr/local/lib/python3.8/site-packages/pexpect/spawnbase.py", line 525, in __exit__
        self.close()
    AttributeError: 'PopenSpawn' object has no attribute 'close'
```

If I try to use spawn class without closing resources I will receive a warning:
```
/usr/local/lib/python3.8/concurrent/futures/thread.py:57: ResourceWarning: unclosed file <_io.FileIO name=35 mode='wb' closefd=True>
  result = self.fn(*self.args, **self.kwargs)
Object allocated at (most recent call last):
  File "/usr/local/lib/python3.8/subprocess.py", lineno 838
    self.stdin = io.open(p2cwrite, 'wb', bufsize)
/usr/local/lib/python3.8/concurrent/futures/thread.py:57: ResourceWarning: unclosed file <_io.FileIO name=36 mode='rb' closefd=True>
  result = self.fn(*self.args, **self.kwargs)
Object allocated at (most recent call last):
  File "/usr/local/lib/python3.8/subprocess.py", lineno 844
    self.stdout = io.open(c2pread, 'rb', bufsize)
```
This is because `proc.stdout` and `proc.stderr` are not being closed automatically.

So I've implemented a `close` method which should properly close all the resources allocated by internal `Popen` instance.