### PR TITLE
Make test_expect.py work on POSIX systems that are not Linux based

### DIFF
--- a/pexpect/bashrc.sh
+++ b/pexpect/bashrc.sh
@@ -14,3 +14,5 @@ PS1="$"
 
 # Unset PROMPT_COMMAND, so that it can't change PS1 to something unexpected.
 unset PROMPT_COMMAND
+
+bind 'set enable-bracketed-paste off'

--- a/tests/PexpectTestCase.py
+++ b/tests/PexpectTestCase.py
@@ -97,7 +97,7 @@ class PexpectTestCase(unittest.TestCase):
                 raise AssertionError("%s was not raised" % excClass)
 
         @contextlib.contextmanager
-        def assertRaisesRegexp(self, excClass, pattern):
+        def assertRaisesRegex(self, excClass, pattern):
             import re
             try:
                 yield

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -456,7 +456,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         child = pexpect.spawn('cat', echo=False)
         child.sendline('BEGIN')
         for i in range(100):
-            child.sendline('foo' * 100)
+            child.sendline('foo' * 10)
         e = child.expect([b'xyzzy', pexpect.TIMEOUT],
                          searchwindowsize=10, timeout=0.001)
         self.assertEqual(e, 1)
@@ -473,7 +473,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
         child = pexpect.spawn('cat', echo=False)
         child.sendline('BEGIN')
         for i in range(100):
-            child.sendline('foo' * 100)
+            child.sendline('foo' * 10)
         e = child.expect([b'xyzzy', pexpect.TIMEOUT],
                          searchwindowsize=10, timeout=0.5)
         self.assertEqual(e, 1)

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -411,7 +411,7 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
     def test_before_across_chunks(self):
         # https://github.com/pexpect/pexpect/issues/478
         child = pexpect.spawn(
-            '''/bin/bash -c "openssl rand -base64 {} 2>/dev/null | head -500 | nl --number-format=rz --number-width=5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
+            '''/bin/sh -c "openssl rand -base64 {} 2>/dev/null | head -500 | nl -n rz -w 5 2>&1 ; echo 'PATTERN!!!'"'''.format(1024 * 1024 * 2),
             searchwindowsize=128
         )
         child.expect(['PATTERN'])

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -569,13 +569,13 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_bad_arg(self):
         p = pexpect.spawn('cat')
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect([1, b'2'])
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact([1, b'2'])
 
     def test_timeout_none(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -214,7 +214,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
         # Force an invalid state to test isalive
         child.ptyproc.terminated = 0
         try:
-            with self.assertRaisesRegexp(pexpect.ExceptionPexpect,
+            with self.assertRaisesRegex(pexpect.ExceptionPexpect,
                                          ".*" + expect_errmsg):
                 child.isalive()
         finally:
@@ -224,7 +224,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
     def test_bad_arguments_suggest_fdpsawn(self):
         " assert custom exception for spawn(int). "
         expect_errmsg = "maybe you want to use fdpexpect.fdspawn"
-        with self.assertRaisesRegexp(pexpect.ExceptionPexpect,
+        with self.assertRaisesRegex(pexpect.ExceptionPexpect,
                                      ".*" + expect_errmsg):
             pexpect.spawn(1)
 

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -110,13 +110,13 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_bad_arg(self):
         p = PopenSpawn('cat')
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect([1, b'2'])
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact([1, b'2'])
 
     def test_timeout_none(self):

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -25,7 +25,7 @@ class REPLWrapTestCase(unittest.TestCase):
 
     def test_bash(self):
         bash = replwrap.bash()
-        res = bash.run_command("alias")
+        res = bash.run_command("alias xyzzy=true; alias")
         assert 'alias' in res, res
 
         try:
@@ -92,7 +92,9 @@ class REPLWrapTestCase(unittest.TestCase):
                                     "PS1='{0}' PS2='{1}' "
                                     "PROMPT_COMMAND=''")
 
+        print(repl)
         res = repl.run_command("echo $HOME")
+        print(res)
         assert res.startswith('/'), res
 
     def test_python(self):


### PR DESCRIPTION
Linux specific commands ans options are used in the test_before_across_chunks function (/bin/bash; nl with long options) which make this test fail on generic POSIX systems. No bash specific features or GNU nl features are used, therefore it is easily possible to make the test run on any POSIX system.

There was an assumption that STDIO buffers are large enough to hold some 10 KB of data. I assume that these buffers are 16 KB on Linux by default, but this is not true for other POSIX systems. The default STDIO buffer size is 4 KB on FreeBSD, for example, which leads to "cat" being blocked waiting to drain its output buffer before it accepts any further input.

The test does not depend on any particular amount of data or characters per line, therefore lines of 39 text characters plus line end characters should be sufficient and does allow systems with 4 KB default STDIO buffer size to successfully execute this test.