### PR TITLE
async for waitnoecho/send/sendline, method naming convention for _async.py

### DIFF
--- a/pexpect/_async.py
+++ b/pexpect/_async.py
@@ -1,11 +1,12 @@
 import asyncio
 import errno
 import signal
+import os
 
 from pexpect import EOF
 
 @asyncio.coroutine
-def expect_async(expecter, timeout=None):
+def Expecter_expect_loop_async(expecter, timeout=None):
     # First process data that was previously read - if it maches, we don't need
     # async stuff.
     idx = expecter.existing_data()
@@ -28,13 +29,13 @@ def expect_async(expecter, timeout=None):
         return expecter.timeout(e)
 
 @asyncio.coroutine
-def repl_run_command_async(repl, cmdlines, timeout=-1):
+def REPLWrapper__run_command_async(repl, command, cmdlines, timeout=-1):
     res = []
-    repl.child.sendline(cmdlines[0])
+    yield from repl.child.sendline(cmdlines[0], async_=True)
     for line in cmdlines[1:]:
         yield from repl._expect_prompt(timeout=timeout, async_=True)
         res.append(repl.child.before)
-        repl.child.sendline(line)
+        yield from repl.child.sendline(line, async_=True)
 
     # Command was fully submitted, now wait for the next prompt
     prompt_idx = yield from repl._expect_prompt(timeout=timeout, async_=True)
@@ -42,7 +43,8 @@ def repl_run_command_async(repl, cmdlines, timeout=-1):
         # We got the continuation prompt - command was incomplete
         repl.child.kill(signal.SIGINT)
         yield from repl._expect_prompt(timeout=1, async_=True)
-        raise ValueError("Continuation prompt found - input was incomplete:")
+        raise ValueError("Continuation prompt found - input was incomplete\n"
+                             + command)
     return u''.join(res + [repl.child.before])
 
 class PatternWaiter(asyncio.Protocol):
@@ -101,3 +103,25 @@ class PatternWaiter(asyncio.Protocol):
             self.eof_received()
         elif exc is not None:
             self.error(exc)
+
+@asyncio.coroutine
+def spawn__waitnoecho_async(spawn, timeout, end_time):
+    while True:
+        if not spawn.getecho():
+            return True
+        if timeout < 0 and timeout is not None:
+            return False
+        if timeout is not None:
+            timeout = end_time - time.time()
+        yield from asyncio.sleep(0.1)
+
+@asyncio.coroutine
+def spawn__send_async(spawn, s):
+    if spawn.delaybeforesend is not None:
+        yield from asyncio.sleep(spawn.delaybeforesend)
+
+    s = spawn._coerce_send_string(s)
+    spawn._log(s, 'send')
+
+    b = spawn._encoder.encode(s, final=False)
+    return os.write(spawn.child_fd, b)

--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -40,7 +40,7 @@ class Expecter(object):
                 spawn._buffer.write(window[-maintain:])
 
     def existing_data(self):
-        # First call from a new call to expect_loop or expect_async.
+        # First call from a new call to expect_loop or Expecter_expect_loop_async.
         # self.searchwindowsize may have changed.
         # Treat all data as fresh.
         spawn = self.spawn

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -341,7 +341,7 @@ class spawn(SpawnBase):
 
         return os.isatty(self.child_fd)
 
-    def waitnoecho(self, timeout=-1):
+    def waitnoecho(self, timeout=-1, async_=False):
         '''This waits until the terminal ECHO flag is set False. This returns
         True if the echo mode is off. This returns False if the ECHO flag was
         not set False before the timeout. This can be used to detect when the
@@ -356,12 +356,27 @@ class spawn(SpawnBase):
 
         If timeout==-1 then this method will use the value in self.timeout.
         If timeout==None then this method to block until ECHO flag is False.
+
+        Like :meth:`expect`, passing ``async_=True`` will make this return an
+        asyncio coroutine.
+
+            p = pexpect.spawn('ssh user@example.com')
+            yield from p.waitnoecho( async_=True )
+            yield from p.sendline(mypassword , async_=True)
         '''
 
         if timeout == -1:
             timeout = self.timeout
         if timeout is not None:
             end_time = time.time() + timeout
+
+        if async_:
+            from ._async import spawn__waitnoecho_async
+            return spawn__waitnoecho_async(self, timeout, end_time)
+        else:
+            return self._waitnoecho(timeout, end_time)
+
+    def _waitnoecho(self, timeout, end_time):
         while True:
             if not self.getecho():
                 return True
@@ -524,7 +539,7 @@ class spawn(SpawnBase):
         for s in sequence:
             self.write(s)
 
-    def send(self, s):
+    def send(self, s, async_=False):
         '''Sends string ``s`` to the child process, returning the number of
         bytes written. If a logfile is specified, a copy is written to that
         log.
@@ -557,8 +572,19 @@ class spawn(SpawnBase):
             >>> bash.sendline('stty -icanon')
             >>> bash.sendline('base64')
             >>> bash.sendline('x' * 5000)
+
+        Like :meth:`expect`, passing ``async_=True`` will make this return an
+        asyncio coroutine.
         '''
 
+        if async_:
+            from ._async import spawn__send_async
+            return spawn__send_async(self, s)
+        else:
+            return self._send(s)
+
+
+    def _send(self, s):
         if self.delaybeforesend is not None:
             time.sleep(self.delaybeforesend)
 
@@ -568,14 +594,17 @@ class spawn(SpawnBase):
         b = self._encoder.encode(s, final=False)
         return os.write(self.child_fd, b)
 
-    def sendline(self, s=''):
+    def sendline(self, s='', async_=False):
         '''Wraps send(), sending string ``s`` to child process, with
         ``os.linesep`` automatically appended. Returns number of bytes
         written.  Only a limited number of bytes may be sent for each
         line in the default terminal mode, see docstring of :meth:`send`.
+
+        Like :meth:`expect`, passing ``async_=True`` will make this return an
+        asyncio coroutine.
         '''
         s = self._coerce_send_string(s)
-        return self.send(s + self.linesep)
+        return self.send(s + self.linesep, async_=async_)
 
     def _log_control(self, s):
         """Write control characters to the appropriate log files"""

--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -89,9 +89,12 @@ class REPLWrapper(object):
             raise ValueError("No command was given")
 
         if async_:
-            from ._async import repl_run_command_async
-            return repl_run_command_async(self, cmdlines, timeout)
+            from ._async import REPLWrapper__run_command_async
+            return REPLWrapper__run_command_async(self, command, cmdlines, timeout)
+        else:
+            return self._run_command(command, cmdlines, timeout)
 
+    def _run_command(self, command, cmdlines, timeout):
         res = []
         self.child.sendline(cmdlines[0])
         for line in cmdlines[1:]:

--- a/pexpect/spawnbase.py
+++ b/pexpect/spawnbase.py
@@ -366,8 +366,8 @@ class SpawnBase(object):
 
         exp = Expecter(self, searcher_re(pattern_list), searchwindowsize)
         if async_:
-            from ._async import expect_async
-            return expect_async(exp, timeout)
+            from ._async import Expecter_expect_loop_async
+            return Expecter_expect_loop_async(exp, timeout)
         else:
             return exp.expect_loop(timeout)
 
@@ -415,8 +415,8 @@ class SpawnBase(object):
 
         exp = Expecter(self, searcher_string(pattern_list), searchwindowsize)
         if async_:
-            from ._async import expect_async
-            return expect_async(exp, timeout)
+            from ._async import Expecter_expect_loop_async
+            return Expecter_expect_loop_async(exp, timeout)
         else:
             return exp.expect_loop(timeout)
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -18,7 +18,7 @@ def run(coro):
 class AsyncTests(PexpectTestCase):
     def test_simple_expect(self):
         p = pexpect.spawn('cat')
-        p.sendline('Hello asyncio')
+        run(p.sendline('Hello asyncio' , async_=True))
         coro = p.expect(['Hello', pexpect.EOF] , async_=True)
         assert run(coro) == 0
         print('Done')
@@ -35,7 +35,7 @@ class AsyncTests(PexpectTestCase):
 
     def test_eof(self):
         p = pexpect.spawn('cat')
-        p.sendline('Hi')
+        run(p.sendline('Hi' , async_=True))
         coro = p.expect(pexpect.EOF, async_=True)
         p.sendeof()
         assert run(coro) == 0


### PR DESCRIPTION
1) method naming convention for _async.py

ClassName_MethodName_async
```
class spawn(SpawnBase):
    def waitnoecho(self, timeout=-1, async_=False):
        if async_:
            from ._async import spawn__waitnoecho_async
            return spawn__waitnoecho_async(self, timeout, end_time)
        else:
            return self._waitnoecho(timeout, end_time)
```
(ClassName is spawn, MethodName is _waitnoecho)

2) async version for:
     spawn.waitnoecho()
     spawn.send()
     spawn.sendline()

3) remove time.sleep() from async methods

4) Results of testing.
20 spawn and 50 fast commands per spawn.
asycsend = True     --     5 sec (theory >2.5 sec)
asycsend = False    --   50 sec (theory >50 sec)


```
import asyncio
import pexpect
import time

async def test_send(num, amode):
    p = pexpect.spawn('python', encoding='utf8')
#    p.delaybeforesend = None
    for j in range(1,50):
        await p.expect(r'>>>', async_=True)
        if amode:
            await p.sendline('print("foo bar")', async_=True)
        else:
            p.sendline('print("foo bar")')
    await p.expect(r'>>>', async_=True)
    await p.sendline('exit()', async_=True)
    await p.expect(pexpect.EOF, async_=True)

async def test_loop(amode=False):
    start = time.time()
    tasks = []
    for i in range(1, 20):
        tasks.append(test_send(i, amode))
    await asyncio.wait(tasks)
    print('All Tasks done in {} seconds (asyncsend={})\n'.format(time.time() - start, amode))

loop = asyncio.get_event_loop()
loop.run_until_complete(test_loop())
loop.run_until_complete(test_loop(True))
```


```
All Tasks done in 49.074270486831665 seconds (asyncsend=False)
All Tasks done in 4.687046527862549 seconds (asyncsend=True)
```


