### PR TITLE
Disallow to use "with" clause with PopenSpawn class

### DIFF
--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -60,7 +60,7 @@ class fdspawn(SpawnBase):
         self.name = '<file descriptor %d>' % fd
         self.use_poll = use_poll
 
-    def close (self):
+    def close(self):
         """Close the file descriptor.
 
         Calling this method a second time does nothing, but if the file
@@ -74,7 +74,7 @@ class fdspawn(SpawnBase):
         self.child_fd = -1
         self.closed = True
 
-    def isalive (self):
+    def isalive(self):
         '''This checks if the file descriptor is still valid. If :func:`os.fstat`
         does not raise an exception then we assume it is alive. '''
 
@@ -146,3 +146,10 @@ class fdspawn(SpawnBase):
             if self.child_fd not in rlist:
                 raise TIMEOUT('Timeout exceeded.')
         return super(fdspawn, self).read_nonblocking(size)
+
+    # For 'with spawn(...) as child:'
+    def __enter__(self):
+        return self
+
+    def __exit__(self, etype, evalue, tb):
+        self.close()

--- a/pexpect/pty_spawn.py
+++ b/pexpect/pty_spawn.py
@@ -853,6 +853,12 @@ class spawn(SpawnBase):
                 self._log(data, 'send')
                 self.__interact_writen(self.child_fd, data)
 
+    # For 'with spawn(...) as child:'
+    def __enter__(self):
+        return self
+
+    def __exit__(self, etype, evalue, tb):
+        self.close()
 
 def spawnu(*args, **kwargs):
     """Deprecated: pass encoding to spawn() instead."""

--- a/pexpect/spawnbase.py
+++ b/pexpect/spawnbase.py
@@ -525,12 +525,3 @@ class SpawnBase(object):
     def isatty(self):
         """Overridden in subclass using tty"""
         return False
-
-    # For 'with spawn(...) as child:'
-    def __enter__(self):
-        return self
-
-    def __exit__(self, etype, evalue, tb):
-        # We rely on subclasses to implement close(). If they don't, it's not
-        # clear what a context manager should do.
-        self.close()


### PR DESCRIPTION
#695 was closed because `Popen.Spawn` implementation could cause blocking the current thread.

So I've removed `__enter__` and `__exit__` methods from this class to disallow users to use `PopenSpawn` as context manager.