### PR TITLE
Ensure test_run.py works when system-wide bashrc produces output

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -22,7 +22,6 @@ PEXPECT LICENSE
 import pexpect
 import unittest
 import subprocess
-import tempfile
 import sys
 import os
 from . import PexpectTestCase
@@ -59,14 +58,9 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
     prep_subprocess_out = staticmethod(lambda x: x)
 
     def setUp(self):
-        fd, self.rcfile = tempfile.mkstemp()
-        os.write(fd, b'PS1=GO: \n')
-        os.close(fd)
+        self.runenv = os.environ.copy()
+        self.runenv['PS1'] = 'GO:'
         super(RunFuncTestCase, self).setUp()
-
-    def tearDown(self):
-        os.unlink(self.rcfile)
-        super(RunFuncTestCase, self).tearDown()
 
     def test_run_exit(self):
         (data, exitstatus) = self.runfunc(sys.executable + ' exit1.py', withexitstatus=1)
@@ -106,9 +100,10 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
         ]
 
         (data, exitstatus) = pexpect.run(
-            'bash --rcfile {0}'.format(self.rcfile),
+            'bash --norc',
             withexitstatus=True,
             events=events,
+            env=self.runenv,
             timeout=10)
         assert exitstatus == 0
 
@@ -118,9 +113,10 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
         ]
 
         (data, exitstatus) = pexpect.run(
-            'bash --rcfile {0}'.format(self.rcfile),
+            'bash --norc',
             withexitstatus=True,
             events=events,
+            env=self.runenv,
             timeout=10)
         assert exitstatus == 0
 
@@ -130,18 +126,20 @@ class RunFuncTestCase(PexpectTestCase.PexpectTestCase):
         ]
 
         (data, exitstatus) = pexpect.run(
-            'bash --rcfile {0}'.format(self.rcfile),
+            'bash --norc',
             withexitstatus=True,
             events=events,
+            env=self.runenv,
             timeout=10)
         assert exitstatus == 0
 
     def test_run_event_typeerror(self):
         events = [('GO:', -1)]
         with self.assertRaises(TypeError):
-            pexpect.run('bash --rcfile {0}'.format(self.rcfile),
+            pexpect.run('bash --norc',
                         withexitstatus=True,
                         events=events,
+                        env=self.runenv,
                         timeout=10)
 
     def _method_events_callback(self, values):


### PR DESCRIPTION
The `--rcfile` option to bash does not prevent the system-wide `/etc/bash.bashrc` script from running (contrary to the Debian man-page). This causes `test_run.py` to fail when the system-wide script produces output (as is the case in an Ubuntu image where the regular user belongs to the "sudo" group and the system-wide script produces an informational message about `sudo` usage).

Rather than rely on `--rcfile`, this patch changes the test to use `--norc` (which does suppress the execution of the system-wide bashrc), and changes `PS1` via the inherited environment instead (this also slightly simplifies the fixture setup too as `tempfile` is no longer required).