### PR TITLE
Remove `pytest-capturelog` from testing requirements

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,4 +2,3 @@ pytest
 pytest-cov
 coverage
 coveralls
-pytest-capturelog


### PR DESCRIPTION
The `pytest-capturelog` plugin no longer exists; its functionality has been merged into the pytest core since ~3.3. Remove the dependency.

Fixes #729