### PR TITLE
tests: Replace assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/tests/PexpectTestCase.py
+++ b/tests/PexpectTestCase.py
@@ -97,7 +97,7 @@ class PexpectTestCase(unittest.TestCase):
                 raise AssertionError("%s was not raised" % excClass)
 
         @contextlib.contextmanager
-        def assertRaisesRegexp(self, excClass, pattern):
+        def assertRaisesRegex(self, excClass, pattern):
             import re
             try:
                 yield

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -643,13 +643,13 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_bad_arg(self):
         p = pexpect.spawn('cat')
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect([1, b'2'])
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact([1, b'2'])
 
     def test_timeout_none(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -214,7 +214,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
         # Force an invalid state to test isalive
         child.ptyproc.terminated = 0
         try:
-            with self.assertRaisesRegexp(pexpect.ExceptionPexpect,
+            with self.assertRaisesRegex(pexpect.ExceptionPexpect,
                                          ".*" + expect_errmsg):
                 child.isalive()
         finally:
@@ -224,7 +224,7 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
     def test_bad_arguments_suggest_fdpsawn(self):
         " assert custom exception for spawn(int). "
         expect_errmsg = "maybe you want to use fdpexpect.fdspawn"
-        with self.assertRaisesRegexp(pexpect.ExceptionPexpect,
+        with self.assertRaisesRegex(pexpect.ExceptionPexpect,
                                      ".*" + expect_errmsg):
             pexpect.spawn(1)
 

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -110,13 +110,13 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 
     def test_bad_arg(self):
         p = PopenSpawn('cat')
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect([1, b'2'])
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact(1)
-        with self.assertRaisesRegexp(TypeError, '.*must be one of'):
+        with self.assertRaisesRegex(TypeError, '.*must be one of'):
             p.expect_exact([1, b'2'])
 
     def test_timeout_none(self):


### PR DESCRIPTION
unittest.TestCase.assertRaisesRegexp was deprecated in Python 3.2 and is removed in Python 3.12.