### PR TITLE
Replace deprecated unittest.makeSuite

### DIFF
--- a/tests/deprecated_test_filedescriptor.py
+++ b/tests/deprecated_test_filedescriptor.py
@@ -72,7 +72,7 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)
 
 #fout = open('delete_me_1','wb')
 #fout.write(the_old_way)

--- a/tests/deprecated_test_run_out_of_pty.py
+++ b/tests/deprecated_test_run_out_of_pty.py
@@ -47,5 +47,5 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)
 

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -236,5 +236,5 @@ class ansiTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ansiTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ansiTestCase)
 

--- a/tests/test_command_list_split.py
+++ b/tests/test_command_list_split.py
@@ -37,4 +37,4 @@ class SplitCommandLineTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(SplitCommandLineTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(SplitCommandLineTestCase)

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -44,5 +44,5 @@ class TestCaseConstructor(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCaseConstructor,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCaseConstructor)
 

--- a/tests/test_ctrl_chars.py
+++ b/tests/test_ctrl_chars.py
@@ -124,5 +124,5 @@ class TestCtrlChars(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCtrlChars,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCtrlChars)
 

--- a/tests/test_destructor.py
+++ b/tests/test_destructor.py
@@ -80,5 +80,5 @@ class TestCaseDestructor(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCaseDestructor,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCaseDestructor)
 

--- a/tests/test_dotall.py
+++ b/tests/test_dotall.py
@@ -39,5 +39,5 @@ class TestCaseDotall(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCaseDotall,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCaseDotall)
 

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -714,4 +714,4 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)

--- a/tests/test_filedescriptor.py
+++ b/tests/test_filedescriptor.py
@@ -69,4 +69,4 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -97,5 +97,5 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(InteractTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(InteractTestCase)
 

--- a/tests/test_isalive.py
+++ b/tests/test_isalive.py
@@ -121,5 +121,5 @@ class IsAliveTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(IsAliveTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(IsAliveTestCase)
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -104,5 +104,5 @@ class TestCaseLog(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCaseLog,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCaseLog)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -370,4 +370,4 @@ class TestCaseMisc(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCaseMisc,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCaseMisc)

--- a/tests/test_missing_command.py
+++ b/tests/test_missing_command.py
@@ -34,5 +34,5 @@ class MissingCommandTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(MissingCommandTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(MissingCommandTestCase)
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -110,4 +110,4 @@ class PerformanceTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == "__main__":
     unittest.main()
 
-suite = unittest.makeSuite(PerformanceTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(PerformanceTestCase)

--- a/tests/test_popen_spawn.py
+++ b/tests/test_popen_spawn.py
@@ -136,4 +136,4 @@ class ExpectTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -282,6 +282,6 @@ class screenTestCase (PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(screenTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(screenTestCase)
 
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -277,4 +277,4 @@ class ExpectTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)

--- a/tests/test_timeout_pattern.py
+++ b/tests/test_timeout_pattern.py
@@ -89,4 +89,4 @@ class Exp_TimeoutTestCase(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(Exp_TimeoutTestCase,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(Exp_TimeoutTestCase)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -184,4 +184,4 @@ class UnicodeTests(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(UnicodeTests, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(UnicodeTests)

--- a/tests/test_winsize.py
+++ b/tests/test_winsize.py
@@ -55,6 +55,6 @@ class TestCaseWinsize(PexpectTestCase.PexpectTestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(TestCaseWinsize,'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(TestCaseWinsize)
 
 


### PR DESCRIPTION
This function was never formally documented, but has been deprecated and will be removed in Python 3.13.  Replaced with unittest.TestLoader.loadTestsFromTestCase.