### PR TITLE
test_interact: update Travis overrides to use generic CI variable

### DIFF
--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -62,8 +62,8 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         p.sendcontrol(']')
         p.expect('29<STOP>')
         p.send('\x00')
-        if not os.environ.get('TRAVIS', None):
-            # on Travis-CI, we sometimes miss trailing stdout from the
+        if not os.environ.get('CI', None):
+            # on CI platforms, we sometimes miss trailing stdout from the
             # chain of child processes, not entirely sure why. So this
             # is skipped on such systems.
             p.expect('0<STOP>')
@@ -84,8 +84,8 @@ class InteractTestCase (PexpectTestCase.PexpectTestCase):
         p.expect('206<STOP>')    # [206, 146]
         p.expect('146<STOP>')
         p.send('\x00')
-        if not os.environ.get('TRAVIS', None):
-            # on Travis-CI, we sometimes miss trailing stdout from the
+        if not os.environ.get('CI', None):
+            # on CI platforms, we sometimes miss trailing stdout from the
             # chain of child processes, not entirely sure why. So this
             # is skipped on such systems.
             p.expect('0<STOP>')


### PR DESCRIPTION
These tests have the same issues on GitHub Actions, so switch to use the more generic 'CI' variable to detect when being run on a CI platform to handle these tests properly.