### PR TITLE
Update Docs Example Python 2 to Python 3

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -45,15 +45,15 @@ ftp to login to the OpenBSD site; list files in a directory; and then pass
 interactive control of the ftp session to the human user::
 
     import pexpect
-    child = pexpect.spawn ('ftp ftp.openbsd.org')
-    child.expect ('Name .*: ')
-    child.sendline ('anonymous')
-    child.expect ('Password:')
-    child.sendline ('noah@example.com')
-    child.expect ('ftp> ')
-    child.sendline ('ls /pub/OpenBSD/')
-    child.expect ('ftp> ')
-    print child.before   # Print the result of the ls command.
+    child = pexpect.spawn('ftp ftp.openbsd.org')
+    child.expect('Name .*: ')
+    child.sendline('anonymous')
+    child.expect('Password:')
+    child.sendline('noah@example.com')
+    child.expect('ftp> ')
+    child.sendline('ls /pub/OpenBSD/')
+    child.expect('ftp> ')
+    print(child.before)   # Print the result of the ls command.
     child.interact()     # Give control of the child to the user.
 
 Special EOF and TIMEOUT patterns


### PR DESCRIPTION
 Update example in doc to use Python 3 print statement. Also update the method calls to match the rest of the document.