### PR TITLE
Add Python 3.5, 3.6 and 3.12.0-rc.1 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        os: ["ubuntu-22.04"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-rc.1", "pypy3.9"]
+        include:
+          # Python < 3.7 is not available on ubuntu-22.04
+          - os: "ubuntu-20.04"
+            python-version: "3.5"
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Closes #762

This adds:
- test against Python 3.5, 3.6 and 3.12.0-rc.1