### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,25 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install packages
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         ./tools/display-sighandlers.py
         ./tools/display-terminalinfo.py
-        py.test --cov pexpect --cov-config .coveragerc
+        pytest --cov pexpect --cov-config .coveragerc
 
     - name: Check coverage
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         pytest --cov pexpect --cov-config .coveragerc
 
     - name: Check coverage
+      if: github.repository_owner == 'pexpect'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 script:
     - ./tools/display-sighandlers.py
     - ./tools/display-terminalinfo.py
-    - py.test --cov pexpect --cov-config .coveragerc
+    - pytest --cov pexpect --cov-config .coveragerc
 
 after_success:
   - coverage combine

--- a/DEVELOPERS.rst
+++ b/DEVELOPERS.rst
@@ -1,6 +1,6 @@
-To run the tests, use `py.test <http://pytest.org/latest/>`_::
+To run the tests, use `pytest <http://pytest.org/latest/>`_::
 
-    py.test tests
+    pytest tests
 
 The tests are all located in the tests/ directory. To add a new unit
 test all you have to do is create the file in the tests/ directory with a

--- a/tests/README
+++ b/tests/README
@@ -1,8 +1,8 @@
 
 The best way to run these tests is from the directory above this one. Run:
 
-    py.test
+    pytest
 
 To run a specific test file:
 
-    py.test tests/test_constructor.py
+    pytest tests/test_constructor.py

--- a/tools/teamcity-runtests.sh
+++ b/tools/teamcity-runtests.sh
@@ -41,7 +41,7 @@ pip install --upgrade pytest-cov coverage coveralls pytest-capturelog
 # run tests
 cd $here/..
 ret=0
-py.test \
+pytest \
 	--cov pexpect \
 	--cov-config .coveragerc \
 	--junit-xml=results.${osrel}.py${pyversion}.xml \
@@ -52,7 +52,7 @@ py.test \
 if [ $ret -ne 0 ]; then
 	# we always exit 0, preferring instead the jUnit XML
 	# results to be the dominate cause of a failed build.
-	echo "py.test returned exit code ${ret}." >&2
+	echo "pytest returned exit code ${ret}." >&2
 	echo "the build should detect and report these failing tests." >&2
 fi
 


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/

---

Also:

* Only try to upload coverage for upstream, it fails for forks
* pytest: drop the dot