### PR TITLE
Add socket_pexpect read logging

### DIFF
--- a/pexpect/socket_pexpect.py
+++ b/pexpect/socket_pexpect.py
@@ -140,6 +140,7 @@ class SocketSpawn(SpawnBase):
                 if s == b'':
                     self.flag_eof = True
                     raise EOF("Socket closed")
+                self._log(s, 'read')
                 return s
         except socket.timeout:
             raise TIMEOUT("Timeout exceeded.")


### PR DESCRIPTION
Using socket pexpect logs only `send*()` payload, however other
pexpect classes logs also received data. This change unifies logging
behaviour for socket pexpect.