### PR TITLE
Time sleep in async (for pexpect v4.9)

### DIFF
--- a/pexpect/_async.py
+++ b/pexpect/_async.py
@@ -20,7 +20,13 @@ if py_version_info >= (3, 6):
         expect_async,
         repl_run_command_async,
         spawn__waitnoecho_async,
-        spawn__send_async
+        spawn__send_async,
+        spawn__write_async,
+        spawn__writelines_async,
+        spawn__terminate_async,
+        spawnbase__read_async,
+        spawnbase__readline_async,
+        spawnbase__readlines_async
     )
 else:
     from pexpect._async_pre_await import (
@@ -28,5 +34,11 @@ else:
         expect_async,
         repl_run_command_async,
         spawn__waitnoecho_async,
-        spawn__send_async
+        spawn__send_async,
+        spawn__write_async,
+        spawn__writelines_async,
+        spawn__terminate_async,
+        spawnbase__read_async,
+        spawnbase__readline_async,
+        spawnbase__readlines_async
     )

--- a/pexpect/_async.py
+++ b/pexpect/_async.py
@@ -19,10 +19,14 @@ if py_version_info >= (3, 6):
         PatternWaiter,
         expect_async,
         repl_run_command_async,
+        spawn__waitnoecho_async,
+        spawn__send_async
     )
 else:
     from pexpect._async_pre_await import (
         PatternWaiter,
         expect_async,
         repl_run_command_async,
+        spawn__waitnoecho_async,
+        spawn__send_async
     )

--- a/pexpect/_async_pre_await.py
+++ b/pexpect/_async_pre_await.py
@@ -5,6 +5,7 @@
 import asyncio
 import errno
 import signal
+import os
 
 from pexpect import EOF
 
@@ -35,13 +36,13 @@ def expect_async(expecter, timeout=None):
 
 
 @asyncio.coroutine
-def repl_run_command_async(repl, cmdlines, timeout=-1):
+def repl_run_command_async(repl, command, cmdlines, timeout=-1):
     res = []
-    repl.child.sendline(cmdlines[0])
+    yield from repl.child.sendline(cmdlines[0], async_=True)
     for line in cmdlines[1:]:
         yield from repl._expect_prompt(timeout=timeout, async_=True)
         res.append(repl.child.before)
-        repl.child.sendline(line)
+        yield from repl.child.sendline(line, async_=True)
 
     # Command was fully submitted, now wait for the next prompt
     prompt_idx = yield from repl._expect_prompt(timeout=timeout, async_=True)
@@ -49,9 +50,31 @@ def repl_run_command_async(repl, cmdlines, timeout=-1):
         # We got the continuation prompt - command was incomplete
         repl.child.kill(signal.SIGINT)
         yield from repl._expect_prompt(timeout=1, async_=True)
-        raise ValueError("Continuation prompt found - input was incomplete:")
+        raise ValueError("Continuation prompt found - input was incomplete\n"
+                             + command)
     return "".join(res + [repl.child.before])
 
+@asyncio.coroutine
+def spawn__waitnoecho_async(spawn, timeout, end_time):
+    while True:
+        if not spawn.getecho():
+            return True
+        if timeout < 0 and timeout is not None:
+            return False
+        if timeout is not None:
+            timeout = end_time - time.time()
+        yield from asyncio.sleep(0.1)
+
+@asyncio.coroutine
+def spawn__send_async(spawn, s):
+    if spawn.delaybeforesend is not None:
+        yield from asyncio.sleep(spawn.delaybeforesend)
+
+    s = spawn._coerce_send_string(s)
+    spawn._log(s, 'send')
+
+    b = spawn._encoder.encode(s, final=False)
+    return os.write(spawn.child_fd, b)
 
 class PatternWaiter(asyncio.Protocol):
     transport = None

--- a/pexpect/_async_pre_await.py
+++ b/pexpect/_async_pre_await.py
@@ -9,6 +9,7 @@ import os
 
 from pexpect import EOF
 
+_loop_getter = asyncio.get_event_loop
 
 @asyncio.coroutine
 def expect_async(expecter, timeout=None):
@@ -17,10 +18,14 @@ def expect_async(expecter, timeout=None):
     idx = expecter.existing_data()
     if idx is not None:
         return idx
+
+    if expecter.spawn.has_eof:
+        return expecter.eof()
+
     if not expecter.spawn.async_pw_transport:
         pw = PatternWaiter()
         pw.set_expecter(expecter)
-        transport, pw = yield from asyncio.get_event_loop().connect_read_pipe(
+        transport, pw = yield from _loop_getter().connect_read_pipe(
             lambda: pw, expecter.spawn
         )
         expecter.spawn.async_pw_transport = pw, transport
@@ -66,6 +71,15 @@ def spawn__waitnoecho_async(spawn, timeout, end_time):
         yield from asyncio.sleep(0.1)
 
 @asyncio.coroutine
+def spawn__write_async(spawn, s):
+    yield from spawn.send(s, async_=True)
+
+@asyncio.coroutine
+def spawn__writelines_async(spawn, sequence):
+    for s in sequence:
+        yield from spawn.write(s, async_=True)
+
+@asyncio.coroutine
 def spawn__send_async(spawn, s):
     if spawn.delaybeforesend is not None:
         yield from asyncio.sleep(spawn.delaybeforesend)
@@ -75,6 +89,107 @@ def spawn__send_async(spawn, s):
 
     b = spawn._encoder.encode(s, final=False)
     return os.write(spawn.child_fd, b)
+
+@asyncio.coroutine
+def spawn__terminate_async(spawn, force=False):
+    if not spawn.isalive():
+        return True
+
+    try:
+        spawn.kill(signal.SIGHUP)
+        yield from asyncio.sleep(spawn.delayafterterminate)
+        if not spawn.isalive():
+            return True
+        spawn.kill(signal.SIGCONT)
+        yield from asyncio.sleep(spawn.delayafterterminate)
+        if not spawn.isalive():
+            return True
+        spawn.kill(signal.SIGINT)
+        yield from asyncio.sleep(spawn.delayafterterminate)
+        if not spawn.isalive():
+            return True
+        if force:
+            spawn.kill(signal.SIGKILL)
+            yield from asyncio.sleep(spawn.delayafterterminate)
+            if not spawn.isalive():
+                return True
+            else:
+                return False
+        return False
+    except OSError:
+        # I think there are kernel timing issues that sometimes cause
+        # this to happen. I think isalive() reports True, but the
+        # process is dead to the kernel.
+        # Make one last attempt to see if the kernel is up to date.
+        yield from asyncio.sleep(spawn.delayafterterminate)
+        if not spawn.isalive():
+            return True
+        else:
+            return False
+
+@asyncio.coroutine
+def spawnbase__read_async(spawn, size):
+
+    if size == 0:
+        return spawn.string_type()
+    if size < 0:
+        # delimiter default is EOF
+        yield from spawn.expect(spawn.delimiter, async_=True)
+        return spawn.before
+
+    # I could have done this more directly by not using expect(), but
+    # I deliberately decided to couple read() to expect() so that
+    # I would catch any bugs early and ensure consistent behavior.
+    # It's a little less efficient, but there is less for me to
+    # worry about if I have to later modify read() or expect().
+    # Note, it's OK if size==-1 in the regex. That just means it
+    # will never match anything in which case we stop only on EOF.
+    cre = re.compile(spawn._coerce_expect_string('.{%d}' % size), re.DOTALL)
+    # delimiter default is EOF
+    index = yield from spawn.expect([cre, spawn.delimiter], async_=True)
+    if index == 0:
+        ### FIXME spawn.before should be ''. Should I assert this?
+        return spawn.after
+    return spawn.before
+
+@asyncio.coroutine
+def spawnbase__readline_async(spawn, size):
+    '''This reads and returns one entire line. The newline at the end of
+    line is returned as part of the string, unless the file ends without a
+    newline. An empty string is returned if EOF is encountered immediately.
+    This looks for a newline as a CR/LF pair (\\r\\n) even on UNIX because
+    this is what the pseudotty device returns. So contrary to what you may
+    expect you will receive newlines as \\r\\n.
+
+    If the size argument is 0 then an empty string is returned. In all
+    other cases the size argument is ignored, which is not standard
+    behavior for a file-like object. '''
+
+    if size == 0:
+        return spawn.string_type()
+    # delimiter default is EOF
+    index = yield from spawn.expect([spawn.crlf, spawn.delimiter], async_=True)
+    if index == 0:
+        return spawn.before + spawn.crlf
+    else:
+        return spawn.before
+
+@asyncio.coroutine
+def spawnbase__readlines_async(spawn, sizehint):
+    '''This reads until EOF using readline() and returns a list containing
+    the lines thus read. The optional 'sizehint' argument is ignored.
+    Remember, because this reads until EOF that means the child
+    process should have closed its stdout. If you run this method on
+    a child that is still running with its stdout open then this
+    method will block until it timesout.'''
+
+    lines = []
+    while True:
+        line = yield from spawn.readline(async_=True)
+        if not line:
+            break
+        lines.append(line)
+    return lines
 
 class PatternWaiter(asyncio.Protocol):
     transport = None
@@ -120,6 +235,7 @@ class PatternWaiter(asyncio.Protocol):
         # for us
         try:
             self.expecter.spawn.flag_eof = True
+            self.expecter.spawn.has_eof = True
             index = self.expecter.eof()
         except EOF as e:
             self.error(e)

--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -161,6 +161,9 @@ class Expecter(object):
             idx = self.existing_data()
             if idx is not None:
                 return idx
+            if spawn.has_eof:
+                return self.eof()
+
             while True:
                 # No match at this point
                 if (timeout is not None) and (timeout < 0):
@@ -176,7 +179,14 @@ class Expecter(object):
                 if timeout is not None:
                     timeout = end_time - time.time()
         except EOF as e:
-            return self.eof(e)
+            spawn.has_eof = True
+            try:
+                eof_index = self.eof(e)
+            except:
+                spawn.close()
+                raise
+            spawn.close()
+            return eof_index
         except TIMEOUT as e:
             return self.timeout(e)
         except:

--- a/pexpect/fdpexpect.py
+++ b/pexpect/fdpexpect.py
@@ -61,6 +61,7 @@ class fdspawn(SpawnBase):
         self.child_fd = fd
         self.own_fd = False
         self.closed = False
+        self.has_eof = False
         self.name = '<file descriptor %d>' % fd
         self.use_poll = use_poll
 

--- a/pexpect/popen_spawn.py
+++ b/pexpect/popen_spawn.py
@@ -53,6 +53,7 @@ class PopenSpawn(SpawnBase):
         self.proc = subprocess.Popen(cmd, **kwargs)
         self.pid = self.proc.pid
         self.closed = False
+        self.has_eof = False
         self._buf = self.string_type()
 
         self._read_queue = Queue()

--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -90,7 +90,7 @@ class REPLWrapper(object):
 
         if async_:
             from ._async import repl_run_command_async
-            return repl_run_command_async(self, cmdlines, timeout)
+            return repl_run_command_async(self, command, cmdlines, timeout)
 
         res = []
         self.child.sendline(cmdlines[0])

--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -65,7 +65,7 @@ class REPLWrapper(object):
         return self.child.expect_exact([self.prompt, self.continuation_prompt],
                                        timeout=timeout, async_=async_)
 
-    def run_command(self, command, timeout=-1, async_=False):
+    def run_command(self, command, timeout=-1, async_=False, **kw):
         """Send a command to the REPL, wait for and return output.
 
         :param str command: The command to send. Trailing newlines are not needed.
@@ -80,6 +80,12 @@ class REPLWrapper(object):
           :mod:`asyncio` Future, which you can yield from to get the same
           result that this method would normally give directly.
         """
+
+        if 'async' in kw:
+            async_ = kw.pop('async')
+        if kw:
+            raise TypeError("Unknown keyword arguments: {}".format(kw))
+
         # Split up multiline commands and feed them in bit-by-bit
         cmdlines = command.splitlines()
         # splitlines ignores trailing newlines - add it back in manually

--- a/pexpect/socket_pexpect.py
+++ b/pexpect/socket_pexpect.py
@@ -62,6 +62,7 @@ class SocketSpawn(SpawnBase):
         self.socket = socket
         self.child_fd = socket.fileno()
         self.closed = False
+        self.has_eof = False
         self.name = "<socket %s>" % socket
         self.use_poll = use_poll
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,6 +12,7 @@ from pexpect import replwrap
 
 from . import PexpectTestCase
 
+_CAT_EOF = b'^D\x08\x08'
 
 @unittest.skipIf(asyncio is None, "Requires asyncio")
 class AsyncTests(PexpectTestCase.AsyncPexpectTestCase):
@@ -85,3 +86,84 @@ class AsyncTests(PexpectTestCase.AsyncPexpectTestCase):
         # Check that the REPL was reset (SIGINT) after the incomplete input
         res = await bash.run_command("echo '1 2\n3 4'", async_=True)
         self.assertEqual(res.strip().splitlines(), ["1 2", "3 4"])
+
+    async def test_terminate_async(self):
+        " test force terminate always succeeds (SIGKILL) in async mode. "
+        child = pexpect.spawn('cat')
+        await child.terminate(force=1, async_=True)
+        await child.terminate(force=1, async_=True)
+        assert child.terminated
+
+    async def test_waitnoecho_async(self):
+        " Tests setecho(False) followed by waitnoecho() "
+        p = pexpect.spawn('cat', echo=False, timeout=5)
+        try:
+            p.setecho(False)
+            await p.waitnoecho(async_=True)
+        except IOError:
+            if sys.platform.lower().startswith('sunos'):
+                if hasattr(unittest, 'SkipTest'):
+                    raise unittest.SkipTest("Not supported on this platform.")
+                return 'skip'
+            raise
+
+    async def test_readline_async(self):
+        " Test spawn.readline(). "
+        # when argument 0 is sent, nothing is returned.
+        # Otherwise the argument value is meaningless.
+        child = pexpect.spawn('cat', echo=False)
+        await child.sendline("alpha", async_=True)
+        await child.sendline("beta", async_=True)
+        await child.sendline("gamma", async_=True)
+        await child.sendline("delta", async_=True)
+        child.sendeof()
+        assert await child.readline(0, async_=True) == b''
+        assert (await child.readline(async_=True)).rstrip() == b'alpha'
+        assert (await child.readline(1, async_=True)).rstrip() == b'beta'
+        assert (await child.readline(2, async_=True)).rstrip() == b'gamma'
+        assert (await child.readline(async_=True)).rstrip() == b'delta'
+        await child.expect(pexpect.EOF, async_=True)
+        assert not child.isalive()
+        assert child.exitstatus == 0
+
+#    async def test_iter_async(self):
+#        " iterating over lines of spawn.__iter__(). "
+#        child = pexpect.spawn('cat', echo=False)
+#        child.sendline("abc")
+#        child.sendline("123")
+#        child.sendeof()
+#        # Don't use ''.join() because we want to test __iter__().
+#        page = b''
+#        for line in child:
+#            page += line
+#        page = page.replace(_CAT_EOF, b'')
+#        assert page == b'abc\r\n123\r\n'
+
+    async def test_readlines_async(self):
+        " reading all lines of spawn.readlines(). "
+        child = pexpect.spawn('cat', echo=False)
+        await child.sendline("abc", async_=True)
+        await child.sendline("123", async_=True)
+        child.sendeof()
+        page = b''.join(await child.readlines(async_=True)).replace(_CAT_EOF, b'')
+        assert page == b'abc\r\n123\r\n'
+        await child.expect(pexpect.EOF, async_=True)
+        assert not child.isalive()
+        assert child.exitstatus == 0
+
+    async def test_write_async(self):
+        " write a character and return it in return. "
+        child = pexpect.spawn('cat', echo=False)
+        await child.write('a', async_=True)
+        await child.write('\r', async_=True)
+        self.assertEqual(await child.readline(async_=True), b'a\r\n')
+
+    async def test_writelines_async(self):
+        " spawn.writelines() "
+        child = pexpect.spawn('cat')
+        # notice that much like file.writelines, we do not delimit by newline
+        # -- it is equivalent to calling write(''.join([args,]))
+        await child.writelines(['abc', '123', 'xyz', '\r'], async_=True)
+        child.sendeof()
+        line = await child.readline(async_=True)
+        assert line == b'abc123xyz\r\n'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -17,7 +17,7 @@ from . import PexpectTestCase
 class AsyncTests(PexpectTestCase.AsyncPexpectTestCase):
     async def test_simple_expect(self):
         p = pexpect.spawn("cat")
-        p.sendline("Hello asyncio")
+        await p.sendline("Hello asyncio", async_=True)
         assert await p.expect(["Hello", pexpect.EOF], async_=True) == 0
         print("Done")
 
@@ -31,7 +31,7 @@ class AsyncTests(PexpectTestCase.AsyncPexpectTestCase):
 
     async def test_eof(self):
         p = pexpect.spawn("cat")
-        p.sendline("Hi")
+        await p.sendline("Hi", async_=True)
         p.sendeof()
         assert await p.expect(pexpect.EOF, async_=True) == 0
 


### PR DESCRIPTION
\# 790 [Pexpect does not implement enough asynchronous methods to prevent the use of time.sleep().](https://github.com/pexpect/pexpect/issues/790)

\# 789 ["expect()" and "await expect()" have different results on completed processes](https://github.com/pexpect/pexpect/issues/789)

See also:
PR \# 710 [async for waitnoecho/send/sendline](https://github.com/pexpect/pexpect/pull/710)

# New async methods #790

New methods:
```
spawn__waitnoecho_async,
spawn__send_async,
spawn__write_async,
spawn__writelines_async,
spawn__terminate_async,
spawnbase__read_async,
spawnbase__readline_async,
spawnbase__readlines_async
```
 have been added.

# Synchronize  "await expect()" vs "expect()" #789

The method "await expect()" always closes the file handler when receiving the EOF.
Added closing of the file handler in the sync method "expect()" when receiving EOF to synchronize with "await expect()".
New code has been added that preserves the old behavior in cases where it is expected.

# New tests for async

```
    async def test_terminate_async(self):
    async def test_waitnoecho_async(self):
    async def test_readline_async(self):
    async def test_readlines_async(self):
    async def test_write_async(self):
    async def test_writelines_async(self):
```

# Results test:
# #789 
```
import asyncio
import pexpect

async def test():
    p = pexpect.spawn('echo 123456', encoding='utf8')
    p.expect(pexpect.EOF)
    print("============ p.expect(pexpect.EOF)")
    print(p)
    p = pexpect.spawn('echo 123456', encoding='utf8')
    await p.expect(pexpect.EOF, async_=True)
    print("============ await p.expect(pexpect.EOF, async=True)")
    print(p)

loop = asyncio.get_event_loop()
loop.run_until_complete(test())
```
than:
> ============ p.expect(pexpect.EOF)
> <pexpect.pty_spawn.spawn object at 0xb6fe2880>
> = 8< ------------- SKIP
> exitstatus: 0
> flag_eof: True
> pid: 30241
> child_fd: 8
> **closed: False**
> = 8< ------------- SKIP
> ============ await p.expect(pexpect.EOF, async=True)
> <pexpect.pty_spawn.spawn object at 0xb6fe2988>
> = 8< ------------- SKIP
> exitstatus: 0
> flag_eof: True
> pid: 30242
> child_fd: -1
> **closed: True**
> = 8< ------------- SKIP

now:
> ============ p.expect(pexpect.EOF)
> <pexpect.pty_spawn.spawn object at 0xb700d880>
> = 8< ------------- SKIP
> exitstatus: 0
> flag_eof: True
> pid: 31025
> child_fd: -1
> **closed: True**
> has_eof: True
> = 8< ------------- SKIP
> ============ await p.expect(pexpect.EOF, async=True)
> <pexpect.pty_spawn.spawn object at 0xb700d988>
> = 8< ------------- SKIP
> exitstatus: 0
> flag_eof: True
> pid: 31026
> child_fd: -1
> **closed: True**
> has_eof: True
> = 8< ------------- SKIP

```
import asyncio
import pexpect
import time

async def test(n1,n2):
    start = time.time()
    p = pexpect.spawn('echo 123456', encoding='utf8')
    if n1:
        res = "      p.expect"
        p.expect(pexpect.EOF)
    else:
        res = "await p.expect"
        await p.expect(pexpect.EOF, async_=True)
    try:
        if n2:
            res = res+"/      p.expect"
            p.expect(pexpect.EOF)
        else:
            res = res+"/await p.expect"
            await p.expect(pexpect.EOF, async_=True)
        print("============ {} -- Ok   time={}".format(res,int(time.time()-start)))
    except:
        print("============ {} -- Fail time={}".format(res,int(time.time()-start)))

async def alltests():
    await test(1,1)    # sync/sync
    await test(1,0)    # sync/async
    await test(0,1)    # async/sync
    await test(0,0)    # async/async

loop = asyncio.get_event_loop()
loop.run_until_complete(alltests())
```
than:
> ============ p.expect/ p.expect -- Ok time=0
> ============ p.expect/await p.expect -- Ok time=0
> ============ await p.expect/ p.expect -- Fail time=0
> ============ await p.expect/await p.expect -- Fail time=30 

now:
> ============       p.expect/      p.expect -- Ok   time=0
> ============       p.expect/await p.expect -- Ok   time=0
> ============ await p.expect/      p.expect -- Ok   time=0
> ============ await p.expect/await p.expect -- Ok   time=0

# #790

Results of testing.
30 spawn and 50 fast commands per spawn.
asycsend = True -- 8 sec
asycsend = False -- 78 sec

```
import asyncio
import pexpect
import time

async def test_send(num, amode):
    p = pexpect.spawn('python3', encoding='utf8')
    for j in range(1,50):
        await p.expect(r'>>>', async_=True)
        if amode:
            await p.sendline('print("foo bar")', async_=True)
        else:
            p.sendline('print("foo bar")')
    await p.expect(r'>>>', async_=True)
    if amode:
        await p.sendline('exit()', async_=True)
    else:
        p.sendline('exit()')
    print("close wait for EOF {}".format(p.child_fd))
    if amode:
        await p.expect(pexpect.EOF, async_=True)
    else:
        p.expect(pexpect.EOF)

async def test_loop(amode=False):
    start = time.time()
    tasks = []
    for i in range(1, 30):
        tasks.append(asyncio.create_task(test_send(i, amode)))
    await asyncio.wait(tasks)
    print('All Tasks done in {} seconds (asyncsend={})\n'.format(time.time() - start, amode))

loop = asyncio.get_event_loop()
loop.run_until_complete(test_loop(True))
loop.run_until_complete(test_loop())
```

> All Tasks done in 7.585522413253784 seconds (asyncsend=True)
> All Tasks done in 78.0375463962555 seconds (asyncsend=False)



