### PR TITLE
Force NO_COLOR=1 to fix test failures with Python 3.13+ REPL

### DIFF
--- a/pexpect/replwrap.py
+++ b/pexpect/replwrap.py
@@ -35,7 +35,7 @@ class REPLWrapper(object):
                  continuation_prompt=PEXPECT_CONTINUATION_PROMPT,
                  extra_init_cmd=None):
         if isinstance(cmd_or_spawn, basestring):
-            self.child = pexpect.spawn(cmd_or_spawn, echo=False, encoding='utf-8')
+            self.child = pexpect.spawn(cmd_or_spawn, echo=False, encoding='utf-8', env={'NO_COLOR': '1'})
         else:
             self.child = cmd_or_spawn
         if self.child.echo:

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -124,7 +124,7 @@ class REPLWrapTestCase(unittest.TestCase):
         if platform.python_implementation() == 'PyPy':
             raise unittest.SkipTest(skip_pypy)
 
-        child = pexpect.spawn(sys.executable, echo=False, timeout=5, encoding='utf-8')
+        child = pexpect.spawn(sys.executable, echo=False, timeout=5, encoding='utf-8', env={'NO_COLOR': '1'})
         # prompt_change=None should mean no prompt change
         py = replwrap.REPLWrapper(child, u">>> ", prompt_change=None,
                                   continuation_prompt=u"... ")


### PR DESCRIPTION
Python 3.13+ has colors now. Always setting this variable should be safe.