### PR TITLE
Wait for child to exit in test_spawn_uses_env

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -65,6 +65,7 @@ class TestCaseEnv(PexpectTestCase.PexpectTestCase):
             child = pexpect.spawn(script, env=environ)
             out = child.readline()
             child.expect(pexpect.EOF)
+            child.wait()
         self.assertEqual(child.exitstatus, 0)
         self.assertEqual(out.rstrip(), b'pexpect test value')
 


### PR DESCRIPTION
Wait for the child to exit before check its exitstatus in test_spawn_uses_env.

This fixes test failure like
https://archriscv.felixc.at/.status/log.htm?url=logs/python-pexpect/python-pexpect-4.9.0-4.log