### PR TITLE
Use date.monotonic() to handle date change

### DIFF
--- a/pexpect/expect.py
+++ b/pexpect/expect.py
@@ -155,7 +155,7 @@ class Expecter(object):
         spawn = self.spawn
 
         if timeout is not None:
-            end_time = time.time() + timeout
+            end_time = time.monotonic() + timeout
 
         try:
             idx = self.existing_data()
@@ -174,7 +174,7 @@ class Expecter(object):
                 if idx is not None:
                     return idx
                 if timeout is not None:
-                    timeout = end_time - time.time()
+                    timeout = end_time - time.monotonic()
         except EOF as e:
             return self.eof(e)
         except TIMEOUT as e:


### PR DESCRIPTION
The expect wait function computed the timeout
based on the current time,
if the system date changes during the wait,
the timeout would be wrongly computed.

I noticed this on a test system where the script was changing the system time, that would lead to an overflow error:
```
OverflowError: timeout is too large
```