### PR TITLE
Fix printing issues in monitor.py

### DIFF
--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -104,7 +104,7 @@ def main():
     #
     # Login via SSH
     #
-    child = pexpect.spawn('ssh -l %s %s'%(user, host))
+    child = pexpect.spawnu('ssh -l %s %s'%(user, host))
     i = child.expect([pexpect.TIMEOUT, SSH_NEWKEY, COMMAND_PROMPT, '(?i)password'])
     if i == 0: # Timeout
         print('ERROR! could not login with SSH. Here is what SSH said:')


### PR DESCRIPTION
Currently monitor example runs into printing issues. Fix it by replacing spawn with unicode-compliant one, which aligns with most of other examples.